### PR TITLE
fix: correct order of checks to see if the subscription is alive

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -23,9 +23,16 @@ class Subscription < ApplicationRecord
     status == 'trialing'
   end
 
-  def is_trial_expiring?
+  def days_to_next_payment
     days_left_in_subscription = (current_period_end.to_date - Time.now.to_date).to_i
-    is_trialing? && days_left_in_subscription < 14
+  end
+
+  def is_trial_expiring?
+    is_trialing? && days_to_next_payment <= 14
+  end
+
+  def is_trial_expired?
+    is_trialing? && days_to_next_payment <= 0
   end
 
   def assign_stripe_attrs(stripe_sub)

--- a/test/unit/subscription_test.rb
+++ b/test/unit/subscription_test.rb
@@ -21,6 +21,17 @@ class SubscriptionTest < ActiveSupport::TestCase
     assert !subscription.is_trial_expiring?
   end
 
+  test 'trial expires if past payment' do
+    subscription = subscriptions(:trialing)
+    assert !subscription.is_trial_expired?
+
+    subscription.current_period_end = Date.today
+    assert subscription.is_trial_expired?
+
+    subscription.current_period_end = 2.days.ago
+    assert subscription.is_trial_expired?
+  end
+
   test 'active subscriptions include trials, past due, and active' do
     trialing = subscriptions(:trialing)
     assert trialing.active_or_trialing?


### PR DESCRIPTION
## Summary

The check for subscription logic was backwards, this was working out for customers benefit as it was never expiring. But after this merge the correct order is used