### PR TITLE
fix: should be using the https version

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "Odonto.me",
   "description": "A barebones Odonto.me applicatoin using Ruby on Rails",
-  "website": "http://www.odonto.me",
+  "website": "https://www.odonto.me",
   "repository": "https://github.com/odontome/app",
   "logo": "https://my.odonto.me/apple-touch-icon-precomposed.png",
   "addons": [

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -43,7 +43,7 @@ class ReviewsController < ApplicationController
         @review.appointment_id = params[:appointment_id]
       end
     rescue Exception
-      redirect_to 'http://www.odonto.me'
+      redirect_to 'https://www.odonto.me'
       return
     end
 

--- a/test/functional/reviews_controller_test.rb
+++ b/test/functional/reviews_controller_test.rb
@@ -24,7 +24,7 @@ class ReviewsControllerTest < ActionController::TestCase
     ciphered_appointment_id = 'not-ciphered-correctly'
 
     get :new, params: { appointment_id: ciphered_appointment_id }
-    assert_redirected_to 'http://www.odonto.me'
+    assert_redirected_to 'https://www.odonto.me'
   end
 
   test 'should create review' do


### PR DESCRIPTION
## Summary

The review email was using the non secure URL, technically this should be configurable as odonto.me is hardcoded in the codebase in a few places