### PR TITLE
feat: support for sending the invite

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,6 +256,9 @@ en:
         subject: Your appointment with %{practice_name} is soon
       appointment_scheduled_email:
         subject: Your appointment with %{practice_name}
+        invite:
+          summary: Dentist appointment
+          description: '%{doctor_name} has scheduled an appointment with you.'
       birthday:
         subject: Happy birthday!
       review:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -238,6 +238,9 @@ es:
         subject: Tu cita con %{practice_name} se acerca
       appointment_scheduled_email:
         subject: Tu cita con %{practice_name}
+        invite:
+          summary: Cita odontologica
+          description: '%{doctor_name} te ha invitado a una cita odontologica.'
       birthday:
         subject: ¡Feliz cumpleaños!
       review:

--- a/test/mailers/previews/patient_mailer_preview.rb
+++ b/test/mailers/previews/patient_mailer_preview.rb
@@ -2,7 +2,6 @@
 
 # Preview all emails at http://localhost:3000/rails/mailers/patient_mailer
 class PatientMailerPreview < ActionMailer::Preview
-  # Preview this email at http://localhost:3000/rails/mailers/patient_mailer/review_recent_appointment
   def review_recent_appointment
     appointment = {
       'appointment_id' => 1,
@@ -12,5 +11,10 @@ class PatientMailerPreview < ActionMailer::Preview
     }
 
     PatientMailer.review_recent_appointment appointment
+  end
+
+  def appointment_scheduled_email
+    doctor = Doctor.last
+    PatientMailer.appointment_scheduled_email("rieraraul@gmail.com", "Raul Riera", 12.hours.from_now, 13.hours.from_now, "Odonto Dev Practice", "es", "UTC", doctor, "practice@practice.com")
   end
 end


### PR DESCRIPTION
## Summary

Adding support for sending a `invite.ics` (pretty much like Google Calendar) whenever someone schedules an appointment with a patient