### PR TITLE
chore: expand the initials functionality and add tests

### DIFF
--- a/app/models/concerns/initials.rb
+++ b/app/models/concerns/initials.rb
@@ -2,6 +2,6 @@ module Initials
   extend ActiveSupport::Concern
   
   def initials
-    firstname.chars.first.upcase + lastname.chars.first.upcase
+    "#{firstname.chars.first&.upcase}#{lastname.chars.first&.upcase}"
   end
 end

--- a/test/unit/doctor_test.rb
+++ b/test/unit/doctor_test.rb
@@ -66,4 +66,10 @@ class DoctorTest < ActiveSupport::TestCase
 
     assert !doctor.is_deleteable
   end
+
+  test 'doctor name can be used as initials' do
+    doctor = Doctor.new(firstname: 'Ruth', lastname: 'Roberts')
+
+    assert_equal doctor.initials, 'RR'
+  end
 end

--- a/test/unit/patient_test.rb
+++ b/test/unit/patient_test.rb
@@ -157,4 +157,14 @@ class PatientTest < ActiveSupport::TestCase
     assert_equal patient.firstname, 'Peter'
     assert_equal patient.lastname, 'Lopez'
   end
+
+  test 'patient name can be used as initials' do
+    patient = Patient.new(firstname: 'Antonio', lastname: 'Santos')
+    patient_empty_firstname = Patient.new(firstname: '', lastname: 'Santos')
+    patient_empty_lastname = Patient.new(firstname: 'Antonio', lastname: '')
+
+    assert_equal patient.initials, 'AS'
+    assert_equal patient_empty_firstname.initials, 'S'
+    assert_equal patient_empty_lastname.initials, 'A'
+  end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -83,4 +83,10 @@ class UserTest < ActiveSupport::TestCase
     assert user.save
     assert_not_equal initial_token, user.perishable_token
   end
+
+  test 'user name can be used as initials' do
+    user = User.new(firstname: 'Esteban', lastname: 'Roberts')
+
+    assert_equal user.initials, 'ER'
+  end
 end


### PR DESCRIPTION
## Summary

The initials functionality now won't break if there wasn't a first name or last name present. These are not optional properties in the respective models, but just in case ™ 