### PR TITLE
feat: add a test for the subscription redirect

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,7 +10,7 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
-development:
+development: &defaults
   secret_key_base: 9d029dc685fbbdf7845894b0f826aa903afdf0ae8c1142e509fa6353ceba635ac515418e9c20ef0c95849ca067d3b2dfd7d80970c82338b0ce12c09a5e43b18d
   stripe_publishable_key: pk_test_lcbdtn4nPblE0uYMkqGLy7GJ
   stripe_secret_key: sk_test_51DsJT5ABOdzKVszlRXjo2ZmUGJrZOJWnBU9XTjBIxgG7IUiiQpUq7loiRlNAjbRdM8lM4Qg9m4xBzQZQ8iaSJtUI00Mm54VHRZ
@@ -18,11 +18,7 @@ development:
   stripe_price_id: price_1JRPagABOdzKVszlVznnsr4Y
 
 test:
-  secret_key_base: 5811a98542ee5d4e46a61e97441f54042809479cd91b48fa675987b2ee50141a8257f551a1a20a2799fca77dd243ab2dfb0901c6c7e2c137a1b396b1bff32bab
-  stripe_publishable_key: <%= ENV["STRIPE_PUBLISHABLE_KEY"] %>
-  stripe_secret_key: <%= ENV["STRIPE_SECRET_KEY"] %>
-  stripe_webhook_secret: <%= ENV["STRIPE_WEBHOOK_SECRET"] %>
-  stripe_price_id: <%= ENV["STRIPE_PRICE_ID"] %>
+  <<: *defaults
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/test/functional/subscriptions_controller_test.rb
+++ b/test/functional/subscriptions_controller_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SubscriptionsControllerTest < ActionController::TestCase
+  setup do
+    @controller.session['user'] = users(:founder)
+  end
+
+  test 'should be redirected to stripe when using a valid configuration' do
+    post :create
+    assert_redirected_to %r(\Ahttps://checkout.stripe.com/pay/)
+  end
+end


### PR DESCRIPTION
## Summary

Upgrading to Rails 7 I almost let this bug slip where you can't redirect without the new property. Adding a test to such redirect so that doesn't happen again (hopefully)