### PR TITLE
test: add tests for associations in Note model

### DIFF
--- a/test/unit/note_test.rb
+++ b/test/unit/note_test.rb
@@ -24,4 +24,18 @@ class NoteTest < ActiveSupport::TestCase
     assert !note.save
     assert_equal I18n.t('errors.messages.too_long', count: 500), note.errors[:notes].join('; ')
   end
+
+  test 'belongs to user' do
+    user = users(:founder)
+    note = Note.new(notes: 'This is a test note', user: user, noteable: patients(:one))
+    assert note.save
+    assert_equal user, note.user
+  end
+
+  test 'belongs to noteable' do
+    patient = patients(:one)
+    note = Note.new(notes: 'This is a test note for noteable', user: users(:founder), noteable: patient)
+    assert note.save
+    assert_equal patient, note.noteable
+  end
 end


### PR DESCRIPTION
This commit adds tests for the `belongs_to :user` and `belongs_to :noteable` associations in the `Note` model.

The tests verify that:
- A Note can be correctly associated with a User.
- A Note can be correctly associated with a polymorphic `noteable` (using Patient as an example).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new unit tests to verify that notes correctly associate with users and with related entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->