### PR TITLE
feat: send a reminder every 6 months to book a new appointment

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Add all the jobs in `/lib/tasks/odontome.rake` to your scheduler:
 - `odontome:send_todays_appointments_to_doctors` - Daily at 7 AM
 - `odontome:send_birthday_wishes_to_patients` - Daily at 3 PM
 - `odontome:send_appointment_review_to_patients` - Every hour
+- `odontome:send_six_month_checkup_reminders` - Every hour (targets 10 AM local time per practice)
 
 ### For Local Development
 You can run these tasks manually for testing:
@@ -291,6 +292,9 @@ You can run these tasks manually for testing:
 ```bash
 # Test a specific task
 bundle exec rake odontome:send_appointment_reminder_notifications
+
+# Test six-month checkup reminders
+bundle exec rake odontome:send_six_month_checkup_reminders
 
 # See all available tasks
 bundle exec rake -T odontome

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -7,6 +7,7 @@ class PatientMailer < ApplicationMailer
       @patient_name = patient_name
       @practice_name = practice_name
       @practice_timezone = practice_timezone
+      @practice_email = practice_email
 
       mail(from: "#{practice_name} <hello@odonto.me>",
            to: patient_email,

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -2,6 +2,18 @@
 require 'icalendar'
 
 class PatientMailer < ApplicationMailer
+  def six_month_checkup_reminder(patient_email, patient_name, practice_name, practice_locale, practice_timezone, practice_email)
+    I18n.with_locale(practice_locale) do
+      @patient_name = patient_name
+      @practice_name = practice_name
+      @practice_timezone = practice_timezone
+
+      mail(from: "#{practice_name} <hello@odonto.me>",
+           to: patient_email,
+           subject: I18n.t('mailers.patient.six_month_checkup_reminder.subject', practice_name: practice_name),
+           reply_to: practice_email)
+    end
+  end
   def appointment_soon_email(patient_email, patient_name, start_time, end_time, practice_name, practice_locale, practice_timezone, doctor, practice_email)
     # temporarily set the locale and then change it back
     # when the block finishes

--- a/app/views/patient_mailer/six_month_checkup_reminder.es.html.erb
+++ b/app/views/patient_mailer/six_month_checkup_reminder.es.html.erb
@@ -1,0 +1,5 @@
+<p>Hola <strong><%= @patient_name %></strong>,</p>
+<p>Han pasado aproximadamente seis meses desde tu última visita con <strong><%= @practice_name %></strong>. Las revisiones regulares ayudan a mantener tu sonrisa saludable. Nos encantará verte de nuevo.</p>
+<p><a href="https://my.odonto.me" target="_blank" rel="noopener">Programa tu cita</a> cuando te convenga.</p>
+<p>Gracias,<br/>
+<%= @practice_name %></p>

--- a/app/views/patient_mailer/six_month_checkup_reminder.es.html.erb
+++ b/app/views/patient_mailer/six_month_checkup_reminder.es.html.erb
@@ -1,5 +1,5 @@
 <p>Hola <strong><%= @patient_name %></strong>,</p>
 <p>Han pasado aproximadamente seis meses desde tu última visita con <strong><%= @practice_name %></strong>. Las revisiones regulares ayudan a mantener tu sonrisa saludable. Nos encantará verte de nuevo.</p>
-<p><a href="https://my.odonto.me" target="_blank" rel="noopener">Programa tu cita</a> cuando te convenga.</p>
+<p><a href="mailto:<%= @practice_email %>" target="_blank" rel="noopener">Programa tu cita</a> cuando te convenga.</p>
 <p>Gracias,<br/>
 <%= @practice_name %></p>

--- a/app/views/patient_mailer/six_month_checkup_reminder.es.text.erb
+++ b/app/views/patient_mailer/six_month_checkup_reminder.es.text.erb
@@ -2,7 +2,7 @@ Hola <%= @patient_name %>,
 
 Han pasado aproximadamente seis meses desde tu última visita con <%= @practice_name %>. Las revisiones regulares ayudan a mantener tu sonrisa saludable. Nos encantará verte de nuevo.
 
-Programa tu cita: https://my.odonto.me
+Programa tu cita: <%= @practice_email %>
 
 Gracias,
 <%= @practice_name %>

--- a/app/views/patient_mailer/six_month_checkup_reminder.es.text.erb
+++ b/app/views/patient_mailer/six_month_checkup_reminder.es.text.erb
@@ -1,0 +1,8 @@
+Hola <%= @patient_name %>,
+
+Han pasado aproximadamente seis meses desde tu última visita con <%= @practice_name %>. Las revisiones regulares ayudan a mantener tu sonrisa saludable. Nos encantará verte de nuevo.
+
+Programa tu cita: https://my.odonto.me
+
+Gracias,
+<%= @practice_name %>

--- a/app/views/patient_mailer/six_month_checkup_reminder.html.erb
+++ b/app/views/patient_mailer/six_month_checkup_reminder.html.erb
@@ -1,5 +1,5 @@
 <p>Hi <strong><%= @patient_name %></strong>,</p>
 <p>It's been about six months since your last visit with <strong><%= @practice_name %></strong>. Regular checkups help keep your smile healthy. We'd be happy to see you again.</p>
-<p><a href="https://my.odonto.me" target="_blank" rel="noopener">Schedule your appointment</a> at your convenience.</p>
+<p><a href="mailto:<%= @practice_email %>" target="_blank" rel="noopener">Schedule your appointment</a> at your convenience.</p>
 <p>Thank you,<br/>
 <%= @practice_name %></p>

--- a/app/views/patient_mailer/six_month_checkup_reminder.html.erb
+++ b/app/views/patient_mailer/six_month_checkup_reminder.html.erb
@@ -1,0 +1,5 @@
+<p>Hi <strong><%= @patient_name %></strong>,</p>
+<p>It's been about six months since your last visit with <strong><%= @practice_name %></strong>. Regular checkups help keep your smile healthy. We'd be happy to see you again.</p>
+<p><a href="https://my.odonto.me" target="_blank" rel="noopener">Schedule your appointment</a> at your convenience.</p>
+<p>Thank you,<br/>
+<%= @practice_name %></p>

--- a/app/views/patient_mailer/six_month_checkup_reminder.text.erb
+++ b/app/views/patient_mailer/six_month_checkup_reminder.text.erb
@@ -1,0 +1,8 @@
+Hi <%= @patient_name %>,
+
+It's been about six months since your last visit with <%= @practice_name %>. Regular checkups help keep your smile healthy. We'd be happy to see you again.
+
+Schedule your appointment: https://my.odonto.me
+
+Thank you,
+<%= @practice_name %>

--- a/app/views/patient_mailer/six_month_checkup_reminder.text.erb
+++ b/app/views/patient_mailer/six_month_checkup_reminder.text.erb
@@ -2,7 +2,7 @@ Hi <%= @patient_name %>,
 
 It's been about six months since your last visit with <%= @practice_name %>. Regular checkups help keep your smile healthy. We'd be happy to see you again.
 
-Schedule your appointment: https://my.odonto.me
+Schedule your appointment: <%= @practice_email %>
 
 Thank you,
 <%= @practice_name %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -265,6 +265,8 @@ en:
         subject: Happy birthday!
       review:
         subject: How was your appointment with %{practice_name}?
+      six_month_checkup_reminder:
+        subject: It's time for your checkup at %{practice_name}
     practice:
       welcome:
         subject: Welcome to Odonto.me

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -247,6 +247,8 @@ es:
         subject: ¡Feliz cumpleaños!
       review:
         subject: ¿Cómo estuvo tu cita en %{practice_name}?
+      six_month_checkup_reminder:
+        subject: Es hora de tu revisión en %{practice_name}
     practice:
       welcome:
         subject: Bienvenido a Odonto.me

--- a/db/migrate/20250809000100_add_six_month_reminder_flag_to_patients.rb
+++ b/db/migrate/20250809000100_add_six_month_reminder_flag_to_patients.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSixMonthReminderFlagToPatients < ActiveRecord::Migration[7.0]
+  def change
+    add_column :patients, :notified_of_six_month_reminder, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_01_01_000001) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_09_000100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -120,6 +120,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_01_01_000001) do
     t.string "drinks_per_day"
     t.text "drugs_use"
     t.text "family_diseases"
+    t.boolean "notified_of_six_month_reminder", default: false, null: false
   end
 
   create_table "practices", id: :serial, force: :cascade do |t|

--- a/lib/tasks/odontome.rake
+++ b/lib/tasks/odontome.rake
@@ -189,8 +189,8 @@ namespace :odontome do
                                    .where(patients: { practice_id: practice_ids })
                                    .group('patients.id, patients.email, patients.firstname, patients.lastname, practices.id, practices.name, practices.locale, practices.timezone, practices.email')
 
-  # Patients with a future confirmed appointment should not receive this reminder
-  future_confirmed_patient_ids = Appointment.joins(:patient)
+    # Patients with a future confirmed appointment should not receive this reminder
+    future_confirmed_patient_ids = Appointment.joins(:patient)
                         .where('appointments.starts_at > ?', Time.now)
                         .where('appointments.status = ?', Appointment.status[:confirmed])
                         .where(patients: { practice_id: practice_ids })
@@ -233,7 +233,11 @@ namespace :odontome do
   def practices_in_timezones(timezones)
     return [] if timezones.empty?
 
-    Practice.select(:id).where(timezone: timezones).pluck(:id)
+    # Only include practices that are active or trialing, and not cancelled
+    Practice.joins(:subscription)
+            .where(timezone: timezones)
+            .where(subscriptions: { status: %w[trialing active] })
+            .pluck(:id)
   end
 
   # find all the admins for the given @practice_ids

--- a/lib/tasks/odontome.rake
+++ b/lib/tasks/odontome.rake
@@ -166,6 +166,47 @@ namespace :odontome do
     end
   end
 
+  desc 'Send six-month checkup reminder to patients (one-time)'
+  task send_six_month_checkup_reminders: :environment do
+    Rails.logger = Logger.new($stdout) if defined?(Rails) && (Rails.env == 'development')
+
+    # Consider practices where local time is mid-morning to avoid odd-hour sends
+    hour_to_send_emails = 10
+    timezones_where_hour_is = timezones_where_hour_are(hour_to_send_emails)
+    practice_ids = practices_in_timezones(timezones_where_hour_is)
+
+    next if practice_ids.empty?
+
+    # Find patients whose last confirmed appointment was > 6 months ago and who have an email
+    # Group by patient to only send once, and respect per-practice locale/timezone
+    six_months_ago = 6.months.ago
+
+    last_appointments = Appointment.select('patients.id as patient_id, patients.email as patient_email, patients.firstname as patient_firstname, patients.lastname as patient_lastname, practices.id as practice_id, practices.name as practice_name, practices.locale as practice_locale, practices.timezone as practice_timezone, practices.email as practice_email, MAX(appointments.ends_at) as last_visit_at')
+                                   .joins(:patient, datebook: :practice)
+                                   .where('appointments.status = ?', Appointment.status[:confirmed])
+                                   .where('appointments.ends_at < ?', six_months_ago)
+                                   .where("patients.email <> ''")
+                                   .where(patients: { practice_id: practice_ids })
+                                   .group('patients.id, patients.email, patients.firstname, patients.lastname, practices.id, practices.name, practices.locale, practices.timezone, practices.email')
+
+    # Filter out patients already notified
+    notified_ids = Patient.where(id: last_appointments.map(&:patient_id)).where(notified_of_six_month_reminder: true).pluck(:id)
+
+    last_appointments.each do |row|
+      next if notified_ids.include?(row['patient_id'] || row.patient_id)
+
+      full_name = [row['patient_firstname'] || row.patient_firstname, row['patient_lastname'] || row.patient_lastname].compact.join(' ')
+      PatientMailer.six_month_checkup_reminder(row['patient_email'] || row.patient_email,
+                                               full_name,
+                                               row['practice_name'] || row.practice_name,
+                                               row['practice_locale'] || row.practice_locale,
+                                               row['practice_timezone'] || row.practice_timezone,
+                                               row['practice_email'] || row.practice_email).deliver_now
+
+      Patient.where(id: row['patient_id'] || row.patient_id).update_all(notified_of_six_month_reminder: true)
+    end
+  end
+
   # find all the timezones where the hour is @hour
   def timezones_where_hour_are(hour)
     time = Time.now

--- a/test/mailers/previews/patient_mailer_preview.rb
+++ b/test/mailers/previews/patient_mailer_preview.rb
@@ -22,4 +22,26 @@ class PatientMailerPreview < ActionMailer::Preview
     doctor = Doctor.last
     PatientMailer.appointment_soon_email("patient@example.com", "John Doe", 24.hours.from_now, 25.hours.from_now, "Dental Practice Example", "en", "Eastern Time (US & Canada)", doctor, "practice@example.com")
   end
+
+  def six_month_checkup_reminder_en
+    PatientMailer.six_month_checkup_reminder(
+      "patient@example.com",
+      "John Doe",
+      "Dental Practice Example",
+      "en",
+      "Eastern Time (US & Canada)",
+      "practice@example.com"
+    )
+  end
+
+  def six_month_checkup_reminder_es
+    PatientMailer.six_month_checkup_reminder(
+      "paciente@example.com",
+      "Juan Pérez",
+      "Clínica Dental Ejemplo",
+      "es",
+      "Eastern Time (US & Canada)",
+      "practica@example.com"
+    )
+  end
 end

--- a/test/unit/six_month_reminder_task_test.rb
+++ b/test/unit/six_month_reminder_task_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rake'
+
+class SixMonthReminderTaskTest < ActiveSupport::TestCase
+  def setup
+    ActionMailer::Base.deliveries.clear
+    @app = Rails.application
+    @app.load_tasks if Rake::Task.tasks.empty?
+    @task = Rake::Task['odontome:send_six_month_checkup_reminders']
+
+    # Choose a timezone where local time is 10 to satisfy the task filter
+    @zone_for_10 = ActiveSupport::TimeZone.all.find { |z| Time.now.in_time_zone(z).hour == 10 }&.name
+    # Fallback to app time zone if none found (shouldn't happen, but keeps test robust)
+    @zone_for_10 ||= Time.zone.name
+  end
+
+  def teardown
+    @task.reenable if @task
+  end
+
+  test 'sends reminder for trialing/active practice and marks patient as notified' do
+  practice = practices(:complete) # has trialing subscription via fixtures
+  practice.update_columns(timezone: @zone_for_10, cancelled_at: nil)
+
+    patient = patients(:one)
+    doctor = doctors(:rebecca)
+    datebook = datebooks(:playa_del_carmen)
+
+    # Ensure patient belongs to the same practice/datebook associations
+    assert_equal practice.id, patient.practice_id
+    assert_equal practice.id, datebook.practice_id
+    assert_equal practice.id, doctor.practice_id
+
+    # Create a confirmed appointment older than 6 months
+    Appointment.create!(
+      datebook_id: datebook.id,
+      doctor_id: doctor.id,
+      patient_id: patient.id,
+      starts_at: 7.months.ago,
+      ends_at: 7.months.ago + 1.hour,
+      status: Appointment.status[:confirmed]
+    )
+
+    # Sanity: patient not notified yet
+    assert_equal false, patient.reload.notified_of_six_month_reminder
+
+  @task.invoke
+
+    # Ensure our target patient received an email and flag was set
+    recipients = ActionMailer::Base.deliveries.map { |m| m.to }.flatten
+    assert_includes recipients, patient.email
+    assert_equal true, patient.reload.notified_of_six_month_reminder
+  end
+
+  test 'skips reminder for past_due and canceled practices' do
+    # past_due practice setup
+  past_due_practice = practices(:past_due_practice)
+  past_due_practice.update_columns(timezone: @zone_for_10, cancelled_at: nil)
+
+    past_due_patient = Patient.create!(
+      practice_id: past_due_practice.id,
+      firstname: 'Past', lastname: 'Due', email: 'pastdue@example.com',
+      date_of_birth: Date.new(1990, 1, 1)
+    )
+    past_due_doctor = Doctor.create!(
+      practice_id: past_due_practice.id,
+      firstname: 'Doc', lastname: 'PD', email: 'docpd@example.com', uid: 'PD1'
+    )
+    past_due_datebook = Datebook.create!(practice_id: past_due_practice.id, name: 'PD')
+    Appointment.create!(
+      datebook_id: past_due_datebook.id,
+      doctor_id: past_due_doctor.id,
+      patient_id: past_due_patient.id,
+      starts_at: 7.months.ago,
+      ends_at: 7.months.ago + 1.hour,
+      status: Appointment.status[:confirmed]
+    )
+
+    # canceled practice setup (explicitly mark cancelled_at)
+  canceled_practice = practices(:canceled_practice)
+  canceled_practice.update_columns(timezone: @zone_for_10, cancelled_at: Time.now)
+
+    canceled_patient = Patient.create!(
+      practice_id: canceled_practice.id,
+      firstname: 'Canceled', lastname: 'Pat', email: 'canceled@example.com',
+      date_of_birth: Date.new(1990, 2, 2)
+    )
+    canceled_doctor = Doctor.create!(
+      practice_id: canceled_practice.id,
+      firstname: 'Doc', lastname: 'C', email: 'docc@example.com', uid: 'C1'
+    )
+    canceled_datebook = Datebook.create!(practice_id: canceled_practice.id, name: 'C')
+    Appointment.create!(
+      datebook_id: canceled_datebook.id,
+      doctor_id: canceled_doctor.id,
+      patient_id: canceled_patient.id,
+      starts_at: 7.months.ago,
+      ends_at: 7.months.ago + 1.hour,
+      status: Appointment.status[:confirmed]
+    )
+
+  @task.invoke
+
+    # No emails sent for either practice
+    assert_equal 0, ActionMailer::Base.deliveries.size
+    # Flags remain false (no notifications sent)
+    assert_equal false, past_due_patient.reload.notified_of_six_month_reminder
+    assert_equal false, canceled_patient.reload.notified_of_six_month_reminder
+  end
+end


### PR DESCRIPTION
This pull request introduces a new six-month checkup reminder system for patients, including backend logic, mailer functionality, localized email templates, and tests. The system ensures that patients receive a one-time reminder if their last confirmed appointment was between six and seven months ago, and resets the reminder flag when a new confirmed appointment is created or updated. The changes also add robust eligibility filtering for practices and patients, and comprehensive automated tests.

**Six-month reminder feature implementation:**

* Added a new boolean column `notified_of_six_month_reminder` to the `patients` table to track whether a patient has been notified. [[1]](diffhunk://#diff-36083786558dd3f3818005c0f5075f05fb44bfe4c0088d8c569562fc5ce9c0a8R1-R7) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R123)
* Implemented a Rake task (`odontome:send_six_month_checkup_reminders`) that finds eligible patients and sends the reminder email, only for practices that are active or trialing and not cancelled, and only if the patient does not already have a future confirmed appointment. [[1]](diffhunk://#diff-f6a46d7dfed81a17e65379785c0c2933a0ae36be835bcb81cc23f446395daa41R169-R218) [[2]](diffhunk://#diff-f6a46d7dfed81a17e65379785c0c2933a0ae36be835bcb81cc23f446395daa41L184-R238)
* In the `Appointment` model, added an `after_commit` callback to reset the six-month reminder flag when a confirmed appointment is created or updated, allowing the patient to be eligible for future reminders. [[1]](diffhunk://#diff-cfdbfa4a779af1691fa6d90113af7e4f4a8ec11815c174a6850a4c7f417845a3R29) [[2]](diffhunk://#diff-cfdbfa4a779af1691fa6d90113af7e4f4a8ec11815c174a6850a4c7f417845a3R104-R118)

**Mailer and localization:**

* Added the `six_month_checkup_reminder` mailer method and corresponding localized subject lines in both English and Spanish. [[1]](diffhunk://#diff-e1494d2e0f3fa7a343018922a9698f1bda3e6f4c28e979c6297f5db15a5d7b2dR5-R17) [[2]](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R268-R269) [[3]](diffhunk://#diff-4bbf4ee302c9607c80408361708b8b9fde3ee7afc5b505bfd69d429dd433f915R250-R251)
* Created new email templates for both HTML and text formats in English and Spanish for the checkup reminder. [[1]](diffhunk://#diff-c3a3d011b72ebf1809f3e370ba74f64f05deec6ca94072f183d310b0372fef4aR1-R5) [[2]](diffhunk://#diff-909bc2c69047da5f7ac8465658cfad84b23c6304182abaa51095e4756a105d49R1-R8) [[3]](diffhunk://#diff-fcbeaee344885bca97a43a10215b312ef5854c64fc6204cc3f2f9d49e597b33cR1-R5) [[4]](diffhunk://#diff-648d67db8ca70b481d7b66fdfa2e11428573d61996023fb29ac1a61423b3f694R1-R8)

**Testing and validation:**

* Added preview methods for the new mailer in `PatientMailerPreview` for both English and Spanish.
* Added unit tests for the appointment model to verify correct resetting of the reminder flag.
* Introduced a comprehensive test suite for the Rake task to validate correct email delivery, flag setting, and exclusion logic for ineligible patients and practices.