### PR TITLE
feat: add new appointed created this week page

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -82,9 +82,17 @@ class AppointmentsController < ApplicationController
     respond_to do |format|
       if @appointment.update(appointment_params)
         format.js {} # update.js.erb
+        format.html do
+          redirect_back fallback_location: practice_appointments_url,
+                        notice: I18n.t(:appointment_updated_success_message)
+        end
       else
         format.js do
           render_ujs_error(@appointment, I18n.t(:appointment_updated_error_message))
+        end
+        format.html do
+          redirect_back fallback_location: practice_appointments_url,
+                        alert: I18n.t(:appointment_updated_error_message)
         end
       end
     end

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -4,7 +4,7 @@ class PracticesController < ApplicationController
   before_action :require_user, only: %i[index destroy edit settings show close]
   before_action :require_no_user, only: %i[new create]
   before_action :require_superadmin, only: %i[index destroy edit]
-  before_action :require_practice_admin, only: %i[show settings balance update close]
+  before_action :require_practice_admin, only: %i[show settings balance appointments update close]
   skip_before_action :check_subscription_status
 
   def index
@@ -163,6 +163,27 @@ class PracticesController < ApplicationController
         headers['Content-Type'] = 'text/csv'
         headers['Content-disposition'] = "attachment; filename=#{starts_at}.csv"
       end
+    end
+  end
+
+  def appointments
+    week_start = DateTime.now.beginning_of_week
+    week_end = DateTime.now.end_of_week
+    @range_label = t('analytics.charts.appointments_this_week')
+    @min_date = @current_user.practice.created_at.strftime('%Y-%m-%d')
+    @max_date = 1.day.from_now.strftime('%Y-%m-%d')
+    date_range = week_start..week_end
+
+    # Scope to current practice via patients join
+  @appointments = Appointment
+      .joins(:patient, :doctor, :datebook)
+      .includes(:patient, :doctor, :datebook)
+      .where(patients: { practice_id: @current_user.practice_id })
+      .where('appointments.starts_at >= ? AND appointments.starts_at <= ?', date_range.begin, date_range.end)
+      .order('datebooks.name ASC, appointments.starts_at ASC')
+
+    respond_to do |format|
+      format.html
     end
   end
 

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -175,12 +175,12 @@ class PracticesController < ApplicationController
     date_range = week_start..week_end
 
     # Scope to current practice via patients join
-  @appointments = Appointment
-      .joins(:patient, :doctor, :datebook)
-      .includes(:patient, :doctor, :datebook)
-      .where(patients: { practice_id: @current_user.practice_id })
-      .where('appointments.starts_at >= ? AND appointments.starts_at <= ?', date_range.begin, date_range.end)
-      .order('datebooks.name ASC, appointments.starts_at ASC')
+    @appointments = Appointment
+                      .joins(:patient, :doctor, :datebook)
+                      .includes(:patient, :doctor, :datebook)
+                      .where(patients: { practice_id: @current_user.practice_id })
+                      .where('appointments.starts_at >= ? AND appointments.starts_at <= ?', date_range.begin, date_range.end)
+                      .order('datebooks.name ASC, appointments.starts_at ASC')
 
     respond_to do |format|
       format.html

--- a/app/views/practices/_weekly_analytics.html.erb
+++ b/app/views/practices/_weekly_analytics.html.erb
@@ -2,7 +2,7 @@
   <!-- KPI cards -->
   <div class="col-sm-3">
     <div class="card card-link">
-      <%= link_to datebooks_url, class: "card-body p-3 d-flex align-items-center justify-content-between card-link" do %>
+      <%= link_to practice_appointments_url, class: "card-body p-3 d-flex align-items-center justify-content-between card-link" do %>
         <div>
           <div class="text-muted"><%= t('analytics.kpis.appointments') %></div>
           <div class="h2 m-0"><%= number_with_delimiter(@kpi_appointments_this_week) %></div>

--- a/app/views/practices/appointments.html.erb
+++ b/app/views/practices/appointments.html.erb
@@ -31,9 +31,7 @@
               <% if @appointments.blank? %>
                 <tr>
                   <td colspan="6">
-                    <%= component :empty, title: t("no_appointments.title"), description: t("no_appointments.description"), image_name: 'calendar.svg' do %>
-                      <%= link_to t(:schedule), root_url, class: "btn btn-primary" %>
-                    <% end %>
+                    <%= t("no_appointments.title") %>
                   </td>
                 </tr>
               <% else %>

--- a/app/views/practices/appointments.html.erb
+++ b/app/views/practices/appointments.html.erb
@@ -37,12 +37,12 @@
                   </td>
                 </tr>
               <% else %>
-        <% current_datebook = nil %>
+                <% current_datebook = nil %>
                 <% @appointments.each do |appointment| %>
                   <% if current_datebook != appointment.datebook_id %>
                     <% current_datebook = appointment.datebook_id %>
                     <tr class="table-active">
-          <td colspan="6"><strong><%= appointment.datebook.name %></strong></td>
+                      <td colspan="6"><strong><%= appointment.datebook.name %></strong></td>
                     </tr>
                   <% end %>
                   <tr>

--- a/app/views/practices/appointments.html.erb
+++ b/app/views/practices/appointments.html.erb
@@ -1,0 +1,123 @@
+<div class="page-header mb-4">
+  <div class="row align-items-center">
+    <div class="col">
+      <div class="page-pretitle">
+        <%= @range_label %>
+      </div>
+      <h2 class="page-title">
+        <%= t :appointments %>
+      </h2>
+    </div>
+  </div>
+</div>
+
+<div class="page-body">
+  <div class="row row-cards">
+    <div class="col-md-12">
+      <div class="card mb-3">
+        <div class="card-table table-responsive">
+          <table class="table table-vcenter table-hover table-mobile-md card-table">
+            <thead>
+              <tr>
+                <th><%= t :patient %></th>
+                <th><%= t('activerecord.attributes.appointment.doctor_id') %></th>
+                <th><%= t :starts_at %></th>
+                <th><%= t :status %></th>
+                <th><%= t :notes %></th>
+                <th class="w-1"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% if @appointments.blank? %>
+                <tr>
+                  <td colspan="6">
+                    <%= component :empty, title: t("no_appointments.title"), description: t("no_appointments.description"), image_name: 'calendar.svg' do %>
+                      <%= link_to t(:schedule), root_url, class: "btn btn-primary" %>
+                    <% end %>
+                  </td>
+                </tr>
+              <% else %>
+        <% current_datebook = nil %>
+                <% @appointments.each do |appointment| %>
+                  <% if current_datebook != appointment.datebook_id %>
+                    <% current_datebook = appointment.datebook_id %>
+                    <tr class="table-active">
+          <td colspan="6"><strong><%= appointment.datebook.name %></strong></td>
+                    </tr>
+                  <% end %>
+                  <tr>
+                    <td data-label="<%= t :patient %>">
+                      <%= link_to appointment.patient.fullname, patient_path(appointment.patient) %>
+                    </td>
+                    <td data-label="<%= t('activerecord.attributes.appointment.doctor_id') %>">
+                      <div class="d-flex py-1 align-items-center">
+                        <span class="avatar me-2" title="<%= appointment.doctor.fullname %>">
+                          <%= appointment.doctor.initials %>
+                          <span class="badge" style="background-color: <%= appointment.doctor.color %>"></span>
+                        </span>
+                        <div class="flex-fill">
+                          <div class="font-weight-medium"><%= appointment.doctor.fullname %></div>
+                        </div>
+                      </div>
+                    </td>
+                    <td data-label="<%= t :starts_at %>">
+                      <span data-bs-toggle="tooltip" data-bs-placement="top" title="<%= l appointment.starts_at.in_time_zone(current_user.practice.timezone), format: :long %>">
+                        <%= l appointment.starts_at.in_time_zone(current_user.practice.timezone), format: :short %>
+                      </span>
+                    </td>
+                    <td data-label="<%= t :status %>">
+                      <% if appointment.is_confirmed %>
+                        <%= label_tag t(:valid), :green %>
+                      <% elsif appointment.is_cancelled %>
+                        <%= label_tag t(:cancel), :red %>
+                      <% else %>
+                        <%= label_tag t(:invalid) %>
+                      <% end %>
+                    </td>
+                    <td data-label="<%= t :notes %>">
+                      <% note = appointment.notes.to_s %>
+                      <% if note.present? %>
+                        <%= content_tag(:span,
+                              truncate(note, length: 25),
+                              title: note,
+                              data: { bs_toggle: 'tooltip', bs_placement: 'top' }) %>
+                      <% end %>
+                    </td>
+                    <td>
+                      <%= component :dropdown do %>
+                        <% if appointment.is_confirmed %>
+                          <%= link_to t(:cancel_appointment),
+                                datebook_appointment_path(appointment.datebook_id, appointment.id, appointment: { status: Appointment.status[:cancelled] }),
+                                method: :patch,
+                                class: "dropdown-item" %>
+                        <% else %>
+                          <%= link_to t(:confirm_appointment),
+                                datebook_appointment_path(appointment.datebook_id, appointment.id, appointment: { status: Appointment.status[:confirmed] }),
+                                method: :patch,
+                                class: "dropdown-item" %>
+                        <% end %>
+                      <% end %>
+                    </td>
+                  </tr>
+                <% end %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="mt-2">
+  <span class="text-muted">
+    <% count = @appointments.size %>
+    <% if count == 1 %>
+      <%= t :appointments_results_one %>
+    <% elsif count <= 20 and count > 1 %>
+      <%= t :appointments_results_few, appointments_count: count %>
+    <% else %>
+      <%= t :appointments_results_many, appointments_count: count %>
+    <% end %>
+  </span>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,6 +120,7 @@ en:
   appointment_created_error_message: The appointment was created successfully
   appointment_date: Date
   appointment_deleted_error_message: There was a problem deleting the appointment
+  appointment_updated_success_message: The appointment was updated successfully
   appointment_updated_error_message: There was a problem updating the appointment
   appointments: Appointments
   appointments_in_datebook: ! "%{count} appointments"
@@ -482,3 +483,9 @@ en:
     labels:
       new: "New"
       returning: "Returning"
+
+  # Appointments list footer counts (similar to patient search results)
+  appointments_results_zero: No appointments were found.
+  appointments_results_one: There was that appointment!
+  appointments_results_few: "%{appointments_count} appointments."
+  appointments_results_many: "Showing %{appointments_count} appointments. Try refining your range."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -116,9 +116,10 @@ es:
   allergic_to: Alérgico a
   already_have_an_account: ¿Ya tienes una cuenta?
   annotate: Anotar
-  appointment_created_error_message: La cita ha sido creada con éxito
+  appointment_created_error_message: Ocurrió un problema al intentar crear la cita.
   appointment_date: Fecha
   appointment_deleted_error_message: Ocurrió un problema al intentar borrar la cita.
+  appointment_updated_success_message: La cita ha sido actualizada con éxito.
   appointment_updated_error_message: Ocurrió un problema al intentar actualizar la cita.
   appointments: Citas
   appointments_in_datebook: ! "%{count} citas"
@@ -432,3 +433,9 @@ es:
     labels:
       new: "Nuevos"
       returning: "Recurrentes"
+
+  # Appointments list footer counts (similar to patient search results)
+  appointments_results_zero: No se encontraron citas.
+  appointments_results_one: ¡Ahí estaba esa cita!
+  appointments_results_few: "%{appointments_count} citas."
+  appointments_results_many: "Mostrando %{appointments_count} citas. Intenta refinar el rango."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   get '/practice' => 'practices#show', :as => :practice
   post '/practice' => 'practices#create'
   get '/practice/balance' => 'practices#balance', :as => :practice_balance
+  get '/practice/appointments' => 'practices#appointments', :as => :practice_appointments
   get '/practice/settings' => 'practices#settings', :as => :practice_settings
   get '/practice/cancel' => 'practices#cancel', :as => :practice_cancel
   post '/practice/close' => 'practices#close', :as => :practice_close


### PR DESCRIPTION
This pull request introduces a new "Practice Appointments" feature, allowing practice admins to view a weekly list of appointments associated with their practice. It adds a new controller action, route, view, and updates access control to support this functionality. Additionally, it improves appointment update feedback and enhances localization for appointment-related messages.

**Feature: Practice Appointments List**

* Added a new `appointments` action to `PracticesController`, which fetches and displays all appointments for the current week, scoped to the current practice, grouped by datebook, and includes relevant patient and doctor details.
* Created a new view `appointments.html.erb` for practices, presenting a responsive table of weekly appointments, handling empty states, and showing a localized count summary in the footer.
* Registered a new route `/practice/appointments` and updated access control to allow only practice admins to access the appointments list. [[1]](diffhunk://#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5R38) [[2]](diffhunk://#diff-6fcf94c5c19cff9d46661551c89f14941fc5636345baaa6d592623988e2afeedL7-R7)
* Updated the weekly analytics card link to point to the new practice appointments page.

<img width="1436" height="946" alt="Screenshot 2025-08-10 at 8 02 14 PM" src="https://github.com/user-attachments/assets/45c98ef5-e0b5-4ae5-9244-22f8c10b70de" />

