### PR TITLE
feat(audits): link to version item

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class AppointmentsController < ApplicationController
-  # layout
+  before_action :require_user
+
   layout false, except: :show
 
   def index

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 class AppointmentsController < ApplicationController
-  # filters
-  before_action :require_user, except: :show
-
   # layout
-  layout false
+  layout false, except: :show
 
   def index
     datebook = Datebook.with_practice(current_user.practice_id).find(params[:datebook_id])
@@ -18,7 +15,7 @@ class AppointmentsController < ApplicationController
                     end
 
     respond_to do |format|
-      format.html # index.html
+      format.html
       format.json { render json: @appointments, methods: %w[doctor patient] }
     end
   end
@@ -45,7 +42,7 @@ class AppointmentsController < ApplicationController
 
     respond_to do |format|
       if datebook_belongs_to_user && @appointment.save
-        format.js {} # create.js.erb
+        format.js {}
       else
         format.js do
           render_ujs_error(@appointment, I18n.t(:appointment_created_error_message))
@@ -55,10 +52,8 @@ class AppointmentsController < ApplicationController
   end
 
   def show
-    appointment_id_deciphered = Cipher.decode(params[:id])
-
-    datebook = Datebook.includes(:practice).find(params[:datebook_id])
-    appointment = Appointment.where(id: appointment_id_deciphered, datebook_id: datebook.id).first
+    datebook = Datebook.with_practice(current_user.practice_id).find(params[:datebook_id])
+    @appointment = Appointment.includes(%i[doctor patient]).where(id: params[:id], datebook_id: datebook.id).first
   end
 
   def edit
@@ -81,7 +76,7 @@ class AppointmentsController < ApplicationController
 
     respond_to do |format|
       if @appointment.update(appointment_params)
-        format.js {} # update.js.erb
+        format.js {}
         format.html do
           redirect_back fallback_location: practice_appointments_url,
                         notice: I18n.t(:appointment_updated_success_message)

--- a/app/controllers/treatments_controller.rb
+++ b/app/controllers/treatments_controller.rb
@@ -11,6 +11,14 @@ class TreatmentsController < ApplicationController
     @treatment = Treatment.new
   end
 
+  def show
+    @treatment = Treatment.with_practice(current_user.practice_id).find(params[:id])
+
+    respond_to do |format|
+      format.html
+    end
+  end
+
   def edit
     @treatment = Treatment.with_practice(current_user.practice_id).find(params[:id])
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
     @user = User.with_practice(current_user.practice_id).find(params[:id])
 
     respond_to do |format|
-      format.html # show.html.erb
+      format.html
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -110,9 +110,15 @@ module ApplicationHelper
     end
   end
 
-  def audit_item_display_name(item, version)
+  def audit_item_link(item, version)
     return deleted_item_display_name(version) unless item
 
+    link_to audit_item_display_name(item, version), item
+  end
+
+  private
+
+  def audit_item_display_name(item, version)
     case version.item_type
     when 'Patient', 'Doctor', 'User'
       item.fullname

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -113,7 +113,15 @@ module ApplicationHelper
   def audit_item_link(item, version)
     return deleted_item_display_name(version) unless item
 
-    link_to audit_item_display_name(item, version), item
+    # Use the correct path helper depending on nesting
+    destination = case version.item_type
+                  when 'Appointment'
+                    [item.datebook, item]
+                  else
+                    item
+                  end
+
+    link_to audit_item_display_name(item, version), destination
   end
 
   private

--- a/app/views/appointments/show.html.erb
+++ b/app/views/appointments/show.html.erb
@@ -1,0 +1,37 @@
+<div class="page-header mb-4">
+  <div class="row align-items-center">
+    <div class="col">
+      <h2 class="page-title">
+        <%= t :appointment %>
+      </h2>
+    </div>
+    <div class="col-auto">
+    </div>
+  </div>
+</div>
+
+<div class="row row-cards">
+    <div class="col-md-12">
+        <div class="card card-md">
+            <div class="card-body">
+                <div class="row">
+                <div class="col-md-6 mb-2">
+                    <%= value_tag t(:patient), link_to(@appointment.patient.fullname, patient_path(@appointment.patient)) %>
+                </div>
+                <div class="col-md-6 mb-2">
+                    <%= value_tag t(:doctor), link_to(@appointment.doctor.fullname, doctor_path(@appointment.doctor)) %>
+                </div>
+                </div>
+            
+                <div class="row">
+                <div class="col-md-6 mb-2">
+                    <%= value_tag t(:starts_at), l(@appointment.starts_at) %>
+                </div>
+                <div class="col-md-6 mb-2">
+                    <%= value_tag t(:ends_at), l(@appointment.ends_at) %>
+                </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -26,7 +26,7 @@
               <div class="col-md-6">
                 <dl class="row">
                   <dt class="col-5"><%= t(:date_time) %>:</dt>
-                  <dd class="col-7"><%= @version.created_at.strftime('%Y-%m-%d %H:%M:%S %Z') %></dd>
+                  <dd class="col-7"><%= l @version.created_at, format: :long %></dd>
                   
                   <dt class="col-5"><%= t(:user) %>:</dt>
                   <dd class="col-7">
@@ -70,7 +70,7 @@
                   
                   <dt class="col-5"><%= t(:item_name) %>:</dt>
                   <dd class="col-7">
-                    <%= audit_item_display_name(@item, @version) %>
+                    <%= audit_item_link @item, @version %>
                   </dd>
                 </dl>
               </div>

--- a/app/views/treatments/show.html.erb
+++ b/app/views/treatments/show.html.erb
@@ -1,0 +1,32 @@
+<div class="page-header mb-4">
+  <div class="row align-items-center">
+    <div class="col">
+      <h2 class="page-title">
+        <%= @treatment.name %>
+      </h2>
+    </div>
+    <div class="col-auto">
+      <div class="btn-list">
+        <%= link_to t(:edit), edit_treatment_path(@treatment), class: "btn" %>
+        <%= link_to t(:delete), @treatment, :method => :delete, data: { confirm: t(:are_you_sure_no_undo) }, class: "btn btn-outline-danger" %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row row-cards">
+    <div class="col-md-12">
+        <div class="card card-md">
+            <div class="card-body">
+                <div class="row">
+                <div class="col-md-6 mb-2">
+                    <%= value_tag t(:name), @treatment.name %>
+                </div>
+                <div class="col-md-6 mb-2">
+                    <%= value_tag t(:price), @treatment.price %>
+                </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
   delete '/admin/impersonate' => 'admin#stop_impersonating', as: :admin_stop_impersonating
 
   # audit trail (for practice admins)
-  resources :audits, only: [:index, :show]
+  resources :audits, only: %i[index show]
 
   # unsubscribe links
   get '/patients/:id/unsubscribe' => 'patients#unsubscribe', :as => :patients_unsubscribe
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
   resource :subscriptions
   namespace :api do
     namespace :webhooks do
-      post "/stripe", to: "stripe#event"
+      post '/stripe', to: 'stripe#event'
     end
   end
 

--- a/test/functional/subscriptions_controller_test.rb
+++ b/test/functional/subscriptions_controller_test.rb
@@ -9,6 +9,6 @@ class SubscriptionsControllerTest < ActionController::TestCase
 
   test 'should be redirected to stripe when using a valid configuration' do
     post :create
-    assert_redirected_to %r(\Ahttps://checkout.stripe.com/c/pay/)
+    assert_redirected_to %r{\Ahttps://checkout.stripe.com/c/pay/}
   end
 end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-require 'test_helper'
-
-class ApplicationHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/practices_helper_test.rb
+++ b/test/unit/helpers/practices_helper_test.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-require 'test_helper'
-
-class PracticesHelperTest < ActionView::TestCase
-end

--- a/test/unit/helpers/sessions_helper_test.rb
+++ b/test/unit/helpers/sessions_helper_test.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-require 'test_helper'
-
-class SessionsHelperTest < ActionView::TestCase
-end


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the appointments, treatments, and audits features, focusing on controller logic, view presentation, helper methods, and minor code style updates. The most important changes include refactoring how appointments and treatments are fetched and displayed, enhancing audit item linking in the audit trail, and adding new show views for appointments and treatments.

### Audit Trail Improvements

* Updated audit helper to provide a link to the audited item when possible, using the appropriate path helpers for nested resources, and updated the audit show view to use this link. (`app/helpers/application_helper.rb`, [[1]](diffhunk://#diff-5f3fc5e3977d242572aa1d08551f5eb557de0ccaff30370838ee9df5386ea0daL113-R129); `app/views/audits/show.html.erb`, [[2]](diffhunk://#diff-1ad8ec786f3abb32d9bd88088d1acf02088684357e298280894475f7b72877f6L73-R73)
* Improved date formatting in the audit show view for better readability. (`app/views/audits/show.html.erb`, [app/views/audits/show.html.erbL29-R29](diffhunk://#diff-1ad8ec786f3abb32d9bd88088d1acf02088684357e298280894475f7b72877f6L29-R29))

These changes improve code clarity, user experience, and maintainability across several parts of the application.

<img width="1436" height="946" alt="Screenshot 2025-08-16 at 9 23 54 PM" src="https://github.com/user-attachments/assets/16353900-e35b-4d69-97ee-a45867582509" />
