### PR TITLE
test(rack-attack): add some tests and format the file

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -12,9 +12,7 @@ class Rack::Attack
   #
   # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
   throttle('logins/ip', limit: 5, period: 20.seconds) do |req|
-    if req.path == '/user_session' && req.post?
-      req.ip
-    end
+    req.ip if req.path == '/user_session' && req.post?
   end
 
   # Throttle POST requests to /user_session by email param
@@ -29,7 +27,7 @@ class Rack::Attack
     if req.path == '/user_session' && req.post?
       # Normalize the email, using the same logic as your authentication process, to
       # protect against rate limit bypasses. Return the normalized email if present, nil otherwise.
-      req.params['signin']['email'].to_s.downcase.gsub(/\s+/, "").presence
+      req.params['signin']['email'].to_s.downcase.gsub(/\s+/, '').presence
     end
   end
 end
@@ -39,7 +37,7 @@ Rack::Attack.blocklist('block suspicious sign up requests') do |req|
   if req.path == '/practice' && req.post?
     practice_name = req.params['practice']['name']
     # There have been multiple instances of spam practices with only a single word in their names and
-    # a vast number of uppercase and lowercase characters. 
+    # a vast number of uppercase and lowercase characters.
     practice_name.split.count == 1 && practice_name.scan(/[A-Z]/).count > 2
   end
 end

--- a/test/functional/rack_attack_test.rb
+++ b/test/functional/rack_attack_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RackAttackTest < ActionDispatch::IntegrationTest
+  def setup
+    # Reset Rack::Attack cache before each test
+    Rack::Attack.cache.store.clear if Rack::Attack.cache.store.respond_to?(:clear)
+    Rack::Attack.reset!
+  end
+
+  def teardown
+    # Clean up after each test
+    Rack::Attack.cache.store.clear if Rack::Attack.cache.store.respond_to?(:clear)
+    Rack::Attack.reset!
+  end
+
+  test 'should throttle requests by IP address' do
+    # First 299 requests should be allowed (limit is 300 per 5 minutes)
+    299.times do |i|
+      get '/signin', headers: { 'REMOTE_ADDR' => '192.168.1.100' }
+      assert_response :success, "Request #{i + 1} should be successful"
+    end
+
+    # 300th request should still be allowed
+    get '/signin', headers: { 'REMOTE_ADDR' => '192.168.1.100' }
+    assert_response :success, '300th request should be successful'
+
+    # 301st request should be throttled
+    get '/signin', headers: { 'REMOTE_ADDR' => '192.168.1.100' }
+    assert_response 429, '301st request should be throttled with 429 status'
+  end
+
+  test 'should throttle login attempts by IP address' do
+    ip_address = '192.168.1.101'
+
+    # First 4 login attempts should be allowed
+    4.times do |i|
+      post '/user_session', params: { signin: { email: 'test@example.com', password: 'wrong' } },
+                            headers: { 'REMOTE_ADDR' => ip_address }
+      assert_response :success, "Login attempt #{i + 1} should be successful"
+    end
+
+    # 5th login attempt should still be allowed
+    post '/user_session', params: { signin: { email: 'test@example.com', password: 'wrong' } },
+                          headers: { 'REMOTE_ADDR' => ip_address }
+    assert_response :success, '5th login attempt should be successful'
+
+    # 6th login attempt should be throttled
+    post '/user_session', params: { signin: { email: 'test@example.com', password: 'wrong' } },
+                          headers: { 'REMOTE_ADDR' => ip_address }
+    assert_response 429, '6th login attempt should be throttled'
+  end
+
+  test 'should throttle login attempts by email' do
+    email = 'throttle.test@example.com'
+
+    # First 4 login attempts should be allowed
+    4.times do |i|
+      post '/user_session', params: { signin: { email: email, password: 'wrong' } },
+                            headers: { 'REMOTE_ADDR' => "192.168.1.#{100 + i}" } # Different IPs
+      puts "Email login attempt #{i + 1}: #{response.status}"
+    end
+
+    # 5th login attempt should still be allowed
+    post '/user_session', params: { signin: { email: email, password: 'wrong' } },
+                          headers: { 'REMOTE_ADDR' => '192.168.1.200' }
+    puts "5th email login attempt: #{response.status}"
+
+    # 6th login attempt should be throttled
+    post '/user_session', params: { signin: { email: email, password: 'wrong' } },
+                          headers: { 'REMOTE_ADDR' => '192.168.1.201' }
+    assert_response 429, '6th email login attempt should be throttled'
+  end
+
+  test 'should block suspicious practice sign up requests' do
+    # Practice name with single word and multiple uppercase characters should be blocked
+    suspicious_name = 'SpAmPrAcTiCe'
+
+    post '/practice', params: { practice: { name: suspicious_name } },
+                      headers: { 'REMOTE_ADDR' => '192.168.1.102' }
+
+    assert_response 403, 'Suspicious practice sign up should be blocked with 403 status'
+  end
+
+  test 'should allow legitimate practice sign up requests' do
+    # Practice name with multiple words should be allowed
+    legitimate_name = 'Dr Smith Dental Practice'
+
+    post '/practice', params: { practice: { name: legitimate_name } },
+                      headers: { 'REMOTE_ADDR' => '192.168.1.103' }
+
+    # Should not be blocked by Rack::Attack (actual response depends on your controller logic)
+    assert_not_equal 403, response.status, 'Legitimate practice sign up should not be blocked'
+  end
+
+  test 'should not throttle asset requests' do
+    # Asset requests should be excluded from throttling
+    301.times do
+      get '/assets/application.css', headers: { 'REMOTE_ADDR' => '192.168.1.104' }
+      # Don't assert success as asset might not exist in test, just ensure not throttled
+      assert_not_equal 429, response.status, 'Asset requests should not be throttled'
+    end
+  end
+
+  test 'different IPs should have separate throttle limits' do
+    # Each IP should have its own throttle counter
+    ip1 = '192.168.1.105'
+    ip2 = '192.168.1.106'
+
+    # Max out requests for IP1
+    300.times do
+      get '/signin', headers: { 'REMOTE_ADDR' => ip1 }
+    end
+
+    # IP1 should be throttled
+    get '/signin', headers: { 'REMOTE_ADDR' => ip1 }
+    assert_response 429, 'IP1 should be throttled'
+
+    # IP2 should still be allowed
+    get '/signin', headers: { 'REMOTE_ADDR' => ip2 }
+    assert_response :success, 'IP2 should not be throttled'
+  end
+end


### PR DESCRIPTION
This pull request improves the reliability and test coverage of our rate-limiting and blocking logic by adding a comprehensive test suite for Rack::Attack, while also making minor code style adjustments to the throttling rules for login attempts. The new tests ensure that throttling and blocking behaviors work as intended for various scenarios, including requests by IP, email, and suspicious practice signups.

**Testing enhancements:**

* Added a new test file `test/functional/rack_attack_test.rb` with integration tests covering IP-based throttling, login attempt throttling by IP and email, blocking suspicious practice signups, allowing legitimate signups, ensuring asset requests are not throttled, and verifying separate throttle limits for different IPs.