### PR TITLE
fix(subscription): prevent creating duplicate customers

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -3,7 +3,7 @@
 class SubscriptionsController < ApplicationController
   before_action :require_practice_admin
   skip_before_action :check_subscription_status
-  
+
   def create
     # Create new Checkout Session for the order
     # See https://stripe.com/docs/api/checkout/sessions/create for more info
@@ -15,15 +15,16 @@ class SubscriptionsController < ApplicationController
         cancel_url: request.base_url + '/practice/settings/',
         payment_method_types: ['card'],
         mode: 'subscription',
-        customer_email: current_user.email,
+        customer: current_user.practice.stripe_customer_id || nil,
+        customer_email: current_user.practice.stripe_customer_id.nil? ? current_user.email : nil,
         client_reference_id: current_user.practice_id,
         automatic_tax: { enabled: true },
         line_items: [{
-            quantity: 1,
-            price: Rails.configuration.stripe[:price_id],
-        }],
+          quantity: 1,
+          price: Rails.configuration.stripe[:price_id]
+        }]
       )
-    rescue => e
+    rescue StandardError => e
       render json: {
         error: e,
         status: 400
@@ -35,9 +36,9 @@ class SubscriptionsController < ApplicationController
 
   def update
     portal_session = Stripe::BillingPortal::Session.create({
-      customer: current_user.practice.stripe_customer_id,
-      return_url: request.base_url + '/practice/settings/',
-    })
+                                                             customer: current_user.practice.stripe_customer_id,
+                                                             return_url: request.base_url + '/practice/settings/'
+                                                           })
     redirect_to portal_session.url, status: 303, allow_other_host: true
   end
 end


### PR DESCRIPTION
Users can create multiple subscriptions, but it's also creating multiple customers. Let's prevent the last part, they can manage the subscriptions directly from the site