### PR TITLE
fix(navigation): practice menu item selection always on

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,11 +35,15 @@ module ApplicationHelper
     params[:controller] == 'datebooks' && params[:id] == id.to_s
   end
 
-  def is_active_tab?(tab)
-    allowed_values = %i[datebooks patients doctors practices users treatments reviews audits]
-    raise "#{tab} is invalid. Allowed values: #{allowed_values.join(', ')}." unless tab.in?(allowed_values)
+  def is_active_tab?(tabs)
+    allowed_values = %i[datebooks patients doctors practices users treatments reviews audits payments]
 
-    controller.controller_name == tab.to_s ? 'active' : ''
+    tabs = Array(tabs).map { |t| t.to_s }
+
+    invalid = tabs.reject { |t| allowed_values.map(&:to_s).include?(t) }
+    raise "#{invalid.join(', ')} are invalid. Allowed values: #{allowed_values.join(', ')}." if invalid.any?
+
+    tabs.include?(controller.controller_name) ? 'active' : ''
   end
 
   def component(name, *options, &block)

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -131,7 +131,7 @@
             </li>
 
             <%# Practice / Dashboard %>
-            <li class="nav-item dropdown <%= is_active_tab?(:practices) || is_active_tab?(:audits) ? 'active' : '' %>">
+            <li class="nav-item dropdown <%= is_active_tab?([:practices, :audits, :payments]) %>">
               <a class="nav-link dropdown-toggle" href="#navbar-practice" data-bs-toggle="dropdown" data-bs-auto-close="outside" role="button" aria-expanded="false">
                 <span class="nav-link-icon d-md-none d-lg-inline-block">
                   <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-building-store" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"> <path stroke="none" d="M0 0h24v24H0z" fill="none"></path> <line x1="3" y1="21" x2="21" y2="21"></line> <path d="M3 7v1a3 3 0 0 0 6 0v-1m0 1a3 3 0 0 0 6 0v-1m0 1a3 3 0 0 0 6 0v-1h-18l2 -4h14l2 4"></path> <line x1="5" y1="21" x2="5" y2="10.85"></line> <line x1="19" y1="21" x2="19" y2="10.85"></line> <path d="M9 21v-4a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v4"></path></svg>

--- a/test/unit/application_helper_test.rb
+++ b/test/unit/application_helper_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  include ApplicationHelper
+
+  test "should return 'active' when controller name matches string tab" do
+    def controller
+      OpenStruct.new(controller_name: 'patients')
+    end
+
+    assert_equal 'active', is_active_tab?('patients')
+    assert_equal '', is_active_tab?('datebooks')
+  end
+
+  test "should return 'active' when controller name matches one tab in array" do
+    def controller
+      OpenStruct.new(controller_name: 'doctors')
+    end
+
+    assert_equal 'active', is_active_tab?(%i[patients doctors treatments])
+    assert_equal '', is_active_tab?(%i[users])
+  end
+
+  test 'should throw an error for invalid tab' do
+    assert_raises(RuntimeError) do
+      is_active_tab?('invalid_tab')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixed an issue where the "practice" menu item was always marked as selected