### PR TITLE
fix(patients): patients created by the calendar weren't able to be found

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -109,6 +109,9 @@ class Patient < ApplicationRecord
       patient.fullname = patient_id_or_name
       # set the practice_id manually because validation (and callbacks apparently as well) are skipped
       patient.practice_id = practice_id
+      # manually set search fields since validation is skipped
+      patient.send(:assign_firstname_initial)
+      patient.send(:set_fullname_search)
       # skip validation when saving this patient
       patient.save!(validate: false)
 

--- a/db/migrate/20251127020806_backfill_patient_search_fields.rb
+++ b/db/migrate/20251127020806_backfill_patient_search_fields.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BackfillPatientSearchFields < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    Patient.where(firstname_initial: nil).or(Patient.where(fullname_search: nil)).find_each do |patient|
+      patient.send(:assign_firstname_initial)
+      patient.send(:set_fullname_search)
+      patient.save!(validate: false)
+    end
+  end
+
+  def down
+    # No rollback needed - these fields should always be populated
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_13_100000) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_27_020806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"

--- a/db/schema_cache.yml
+++ b/db/schema_cache.yml
@@ -1888,4 +1888,4 @@ indexes:
     nulls_not_distinct: false
     comment:
     valid: true
-version: 20251113100000
+version: 20251127020806

--- a/test/unit/models/patient_test.rb
+++ b/test/unit/models/patient_test.rb
@@ -191,4 +191,33 @@ class PatientTest < ActiveSupport::TestCase
     assert_equal patient_empty_firstname.initials, 'S'
     assert_equal patient_empty_lastname.initials, 'A'
   end
+
+  test 'find_or_create_from sets search fields when creating new patient' do
+    practice_id = practices(:complete).id
+    patient_id = Patient.find_or_create_from('Maria Garcia'.dup, practice_id)
+    patient = Patient.find(patient_id)
+
+    assert_equal 'Maria', patient.firstname
+    assert_equal 'Garcia', patient.lastname
+    assert_equal 'm', patient.firstname_initial, 'firstname_initial should be set for index lookup'
+    assert_equal 'maria garcia', patient.fullname_search, 'fullname_search should be set for search'
+  end
+
+  test 'find_or_create_from patient is findable by anything_with_letter scope' do
+    practice_id = practices(:complete).id
+    patient_id = Patient.find_or_create_from('Carlos Rodriguez'.dup, practice_id)
+
+    result_ids = Patient.anything_with_letter('C').with_practice(practice_id).map(&:id)
+
+    assert_includes result_ids, patient_id, 'Patient created via find_or_create_from should appear in letter index'
+  end
+
+  test 'find_or_create_from patient is findable by search scope' do
+    practice_id = practices(:complete).id
+    patient_id = Patient.find_or_create_from('Sofia Martinez'.dup, practice_id)
+
+    result_ids = Patient.search('Sofia').with_practice(practice_id).map(&:id)
+
+    assert_includes result_ids, patient_id, 'Patient created via find_or_create_from should be searchable'
+  end
 end


### PR DESCRIPTION
This pull request ensures that patient search fields (`firstname_initial` and `fullname_search`) are correctly set when creating new patients, and provides a migration to backfill these fields for existing records. It also adds tests to confirm these behaviors. The key changes are grouped below: