### PR TITLE
fix(appointments): prevent OOM crashes and handle missing records

### DIFF
--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -42,7 +42,11 @@ class Practice < ApplicationRecord
   end
 
   def populate_default_treatments
-    Rails.configuration.patient_treatments[locale || 'en']['treatments'].each do |treatment|
+    locale_key = locale.presence || 'en'
+    treatments_config = Rails.configuration.patient_treatments[locale_key] || Rails.configuration.patient_treatments['en']
+    return unless treatments_config
+
+    treatments_config['treatments'].each do |treatment|
       treatments << Treatment.new(name: treatment, price: 0)
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,7 @@ en:
   appointment_deleted_error_message: There was a problem deleting the appointment
   appointment_updated_success_message: The appointment was updated successfully
   appointment_updated_error_message: There was a problem updating the appointment
+  appointment_not_found_message: Appointment not found. It may have been deleted by another user or never existed.
   appointments: Appointments
   appointments_in_datebook: ! "%{count} appointments"
   are_you_sure: Are you sure?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -127,6 +127,7 @@ es:
   appointment_deleted_error_message: Ocurrió un problema al intentar borrar la cita.
   appointment_updated_success_message: La cita ha sido actualizada con éxito.
   appointment_updated_error_message: Ocurrió un problema al intentar actualizar la cita.
+  appointment_not_found_message: Cita no encontrada. Es posible que haya sido eliminada por otro usuario o que nunca haya existido.
   appointments: Citas
   appointments_in_datebook: ! "%{count} citas"
   are_you_sure: ¿Estás seguro?

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -126,6 +126,7 @@ pt:
   appointment_deleted_error_message: Houve um problema ao deletar o agendamento
   appointment_updated_success_message: O agendamento foi atualizado com sucesso
   appointment_updated_error_message: Houve um problema ao atualizar o agendamento
+  appointment_not_found_message: Agendamento não encontrado. Pode ter sido excluído por outro usuário ou nunca ter existido.
   appointments: Agendamentos
   appointments_in_datebook: ! "%{count} agendamentos"
   are_you_sure: Tem certeza?

--- a/test/functional/appointments_controller_test.rb
+++ b/test/functional/appointments_controller_test.rb
@@ -8,9 +8,17 @@ class AppointmentsControllerTest < ActionController::TestCase
   end
 
   test 'should get index' do
-    get :index, params: { datebook_id: 1 }, format: :json
+    start_ts = 1.month.ago.to_i
+    end_ts   = 1.month.from_now.to_i
+    get :index, params: { datebook_id: 1, start: start_ts, end: end_ts }, format: :json
     assert_response :success
     assert_not_nil assigns(:appointments)
+  end
+
+  test 'should return empty array when index is missing date params' do
+    get :index, params: { datebook_id: 1 }, format: :json
+    assert_response :success
+    assert_equal '[]', response.body
   end
 
   test 'should get new' do
@@ -113,10 +121,10 @@ class AppointmentsControllerTest < ActionController::TestCase
     assert_equal updated_appointment.ends_at.to_time.to_i, new_ends_at.to_time.to_i
   end
 
-  test 'should return not found for appointment not in datebook' do
-    assert_raises(ActiveRecord::RecordNotFound) do
-      get :show, params: { datebook_id: 1, id: 999999 }, format: :html
-    end
+  test 'should alert when appointment not found' do
+    get :show, params: { datebook_id: 1, id: 999999 }, format: :html
+    assert_response :success
+    assert_includes response.body, "alert("
   end
 
   test 'should not create an appointment with in a foreign practice' do


### PR DESCRIPTION
## Summary

- **#894 / #866 (OOM in appointments#index):** Guard against nil/unbounded date params that caused `PG::OutOfMemory` by querying all rows since 1970. Cap the query window to 90 days max. #866 closed as duplicate of #894.
- **#888, #919, #920 (nil @appointment):** Rescue `ActiveRecord::RecordNotFound` across all appointment actions and show a localized JS alert instead of rendering the full page inside the calendar modal.
- **#889 (treatments locale nil):** `populate_default_treatments` now falls back to the English config when the practice locale isn't in `treatments.yml` (e.g., `pt`), preventing `NoMethodError` on nil.

Closes #894, closes #888, closes #919, closes #920, closes #889

## Test plan

- [x] Existing tests updated and passing (303 runs, 0 failures)
- [x] Verify calendar loads appointments normally with valid date range
- [x] Verify calendar returns empty when start/end params are missing
- [x] Click a deleted/nonexistent appointment and confirm JS alert appears without rendering full page in modal
- [x] Create a practice with `pt` locale and load predefined treatments — should fall back to English

🤖 Generated with [Claude Code](https://claude.com/claude-code)