### PR TITLE
fix(rake): prevent PostgreSQL OOM in rake tasks and Patient callback

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -145,7 +145,7 @@ class Patient < ApplicationRecord
 
   # this function is a small compromise to bypass that weird situation where a patient is created with everything set to nil
   def destroy_nils
-    Patient.where(firstname: nil).destroy_all
-    Appointment.where(patient_id: nil).destroy_all
+    Patient.where(firstname: nil, practice_id: practice_id).delete_all
+    Appointment.where(patient_id: nil).delete_all
   end
 end

--- a/test/unit/tasks/appointment_review_task_test.rb
+++ b/test/unit/tasks/appointment_review_task_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AppointmentReviewTaskTest < RakeTaskTestCase
+  rake_task 'odontome:send_appointment_review_to_patients'
+
+  def setup
+    super
+    travel_to Time.utc(2025, 1, 1, 9, 0, 0)
+    ActionMailer::Base.deliveries.clear
+  end
+
+  def teardown
+    travel_back
+    super
+  end
+
+  test 'sends review email for confirmed appointments ended 45min to 3 days ago' do
+    appointment = create_appointment(ends_at: 2.hours.ago)
+
+    @task.invoke
+
+    assert_equal 1, ActionMailer::Base.deliveries.count
+    assert appointment.reload.notified_of_review
+  end
+
+  test 'marks appointments as notified_of_review' do
+    appointment = create_appointment(ends_at: 1.day.ago)
+
+    @task.invoke
+
+    assert appointment.reload.notified_of_review
+  end
+
+  test 'skips already-notified appointments' do
+    appointment = create_appointment(ends_at: 2.hours.ago, notified_of_review: true)
+
+    assert_raises(SystemExit) { @task.invoke }
+
+    assert_empty ActionMailer::Base.deliveries
+    assert appointment.reload.notified_of_review
+  end
+
+  test 'skips cancelled appointments' do
+    appointment = create_appointment(ends_at: 2.hours.ago, status: Appointment.status[:cancelled])
+
+    assert_raises(SystemExit) { @task.invoke }
+
+    assert_empty ActionMailer::Base.deliveries
+    refute appointment.reload.notified_of_review
+  end
+
+  test 'skips appointments ended less than 45 minutes ago' do
+    appointment = create_appointment(ends_at: 30.minutes.ago)
+
+    assert_raises(SystemExit) { @task.invoke }
+
+    assert_empty ActionMailer::Base.deliveries
+    refute appointment.reload.notified_of_review
+  end
+
+  private
+
+  def create_appointment(starts_at: nil, ends_at: 2.hours.ago,
+                         patient: patients(:one),
+                         doctor: doctors(:rebecca),
+                         datebook: datebooks(:playa_del_carmen),
+                         status: Appointment.status[:confirmed],
+                         notified_of_review: false)
+    starts_at ||= ends_at - 1.hour
+
+    Appointment.create!(
+      datebook: datebook,
+      doctor: doctor,
+      patient: patient,
+      starts_at: starts_at,
+      ends_at: ends_at,
+      status: status,
+      notified_of_review: notified_of_review
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #931 — PostgreSQL OOM crash on 2026-02-27 that cascaded into 28+ Bugsnag issues.

- **Scoped `destroy_nils` to current practice** and switched from `destroy_all` to `delete_all` — was scanning/loading ALL patients across ALL practices on every patient creation
- **Disabled PostgreSQL parallel workers** in all 6 notification rake tasks via `disable_parallel_workers` helper — parallel workers were multiplying memory consumption
- **Added eager loading** (`includes(datebook: :practice)`) to reminder and scheduled tasks — eliminated N+1 queries on `appointment.datebook.practice`
- **Replaced unbounded `.each`** with `find_each` for batched iteration (1,000 records at a time)
- **Replaced `.map(&:appointment_id)`** with already-loaded array in review task — avoids materializing IDs separately
- **Converted Array to Set** for O(1) lookups in six-month reminder task

Closed 29 duplicate issues (#840, #932–#942, #944–#961) as symptoms of the same incident.

## Test plan

- [x] Added 2 tests for `destroy_nils` (practice scoping + callback wiring)
- [x] Added 5 tests for `send_appointment_review_to_patients` (new test file)
- [x] All 10 existing notification task tests pass
- [x] Full suite: 408 tests, 0 failures
- [x] Verified SQL output confirms single eager-loaded query with `LIMIT 1000` batching

🤖 Generated with [Claude Code](https://claude.com/claude-code)