### PR TITLE
test(subscriptions): add expiring banner coverage

### DIFF
--- a/test/functional/application_controller_test.rb
+++ b/test/functional/application_controller_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationControllerTest < ActionController::TestCase
+  tests PatientsController
+
+  setup do
+    @controller.session['user'] = users(:founder)
+  end
+
+  test 'shows expiring subscription warning banner on authenticated pages' do
+    users(:founder).practice.subscription.update_columns(current_period_end: 6.days.from_now)
+    expected_warning = I18n.t('subscriptions.errors.expiring', practice_settings_url: practice_settings_url)
+
+    get :index
+
+    assert_response :success
+    assert_equal expected_warning, flash[:warning].to_s
+    assert_select '.alert.alert-warning .text-muted', text: /Your subscription will expire soon/
+    assert_includes response.body, expected_warning
+  end
+end


### PR DESCRIPTION
This pull request adds a new functional test for the application controller to ensure that users see a warning banner when their subscription is about to expire. The test simulates an authenticated user with an expiring subscription and verifies that the correct warning message is displayed.

Testing improvements:

* Added `ApplicationControllerTest` in `test/functional/application_controller_test.rb` to verify that an expiring subscription warning banner is shown to authenticated users when their subscription is close to expiring.