### PR TITLE
feat(subscriptions): trial lifecycle emails, browser locale detection, honest trial copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,13 +303,16 @@ Add all the jobs in `/lib/tasks/odontome.rake` to your scheduler:
   - Requests reviews from patients after appointments
 - `odontome:send_six_month_checkup_reminders` - Every hour (targets 10 AM local time per practice)
   - Reminds patients about their 6-month dental checkups
+- `odontome:practice_lifecycle` - Every hour (targets 10 AM local time per practice)
+  - Single hub job for trial lifecycle emails: day-2 activation nudge, day-25 trial-ending
+    notice, day-31 trial-ended notice, and day-37 deletion warning
 
 #### Maintenance Tasks
 
 - `odontome:cleanup_audit_logs` - Daily
   - Removes audit logs older than 30 days to prevent database bloat
 - `odontome:cleanup_old_practices` - Daily
-  - Deletes practices older than 7 days with 0 patients
+  - Deletes practices older than 40 days with 0 patients (they receive a warning email at day 37)
 - `odontome:mark_inactive_practices_for_cancellation` - Daily
   - Marks practices for cancellation where no user has logged in for 60+ days (excludes active subscriptions)
 - `odontome:delete_practices_cancelled_a_while_ago` - Daily

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,7 +45,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    I18n.locale = current_user&.practice&.locale || I18n.default_locale
+    I18n.locale = current_user&.practice&.locale || browser_locale || I18n.default_locale
   end
 
   def set_timezone
@@ -53,6 +53,15 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  # Best-effort match of the browser's Accept-Language header against our
+  # supported locales. Quality values are ignored on purpose: with only
+  # three locales, first match in header order is correct in practice.
+  def browser_locale
+    header = request.headers['Accept-Language'].to_s
+    header.split(',').map { |entry| entry.split(';').first.to_s.strip.downcase[0, 2] }
+          .find { |code| %w[en es pt].include?(code) }
+  end
 
   def redirect_to_subscription_error
     if user_is_admin?

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -81,6 +81,7 @@ class PracticesController < ApplicationController
 
   def create
     @practice = Practice.new(practice_params)
+    @practice.locale = browser_locale || 'en'
 
     unless params[:consent_terms] == "1" && params[:consent_privacy] == "1"
       @practice.errors.add(:base, I18n.t(:consent_required))

--- a/app/mailers/practice_mailer.rb
+++ b/app/mailers/practice_mailer.rb
@@ -4,7 +4,38 @@ class PracticeMailer < ApplicationMailer
   helper ApplicationHelper
 
   def welcome_email(practice)
-    mail(to: practice.email, subject: I18n.t('mailers.practice.welcome.subject'))
+    I18n.with_locale(practice.locale) do
+      mail(to: practice.email, subject: I18n.t('mailers.practice.welcome.subject'))
+    end
+  end
+
+  def activation_nudge(practice)
+    I18n.with_locale(practice.locale) do
+      mail(to: practice.email, subject: I18n.t('mailers.practice.activation_nudge.subject'))
+    end
+  end
+
+  def trial_ending(practice)
+    @trial_ends_on = practice.subscription.current_period_end.strftime('%d/%m/%Y')
+    @price = Rails.configuration.stripe[:price_display]
+
+    I18n.with_locale(practice.locale) do
+      mail(to: practice.email, subject: I18n.t('mailers.practice.trial_ending.subject'))
+    end
+  end
+
+  def trial_ended(practice)
+    @price = Rails.configuration.stripe[:price_display]
+
+    I18n.with_locale(practice.locale) do
+      mail(to: practice.email, subject: I18n.t('mailers.practice.trial_ended.subject'))
+    end
+  end
+
+  def deletion_warning(practice)
+    I18n.with_locale(practice.locale) do
+      mail(to: practice.email, subject: I18n.t('mailers.practice.deletion_warning.subject'))
+    end
   end
 
   def new_review_notification(review)

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -190,10 +190,10 @@ class Practice < ApplicationRecord
     end
 
     self.timezone = tz&.name || Time.zone.name
-    self.locale = "en"
+    self.locale = 'en' unless %w[en es pt].include?(locale)
   rescue StandardError
     self.timezone = Time.zone.name
-    self.locale = "en"
+    self.locale = 'en' unless %w[en es pt].include?(locale)
   end
 
   def set_first_user_data

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -28,7 +28,7 @@ class Subscription < ApplicationRecord
   end
 
   def is_trial_expiring?
-    is_trialing? && days_to_next_payment <= 14
+    is_trialing? && days_to_next_payment <= 7
   end
 
   def is_trial_expired?

--- a/app/views/practice_mailer/activation_nudge.es.html.erb
+++ b/app/views/practice_mailer/activation_nudge.es.html.erb
@@ -1,0 +1,23 @@
+<tr>
+	<td class="content-block">
+		<h2>Tu clínica está lista.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Agregar tu primer paciente es la mejor manera de ver cómo funciona Odonto.me &mdash; las citas, los recordatorios y los expedientes comienzan ahí. Solo toma un minuto.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/patients/new" class="btn-primary">Agregar mi primer paciente</a>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		¿Dudas? Responde a este correo y te ayudamos a comenzar.
+	</td>
+</tr>

--- a/app/views/practice_mailer/activation_nudge.es.text.erb
+++ b/app/views/practice_mailer/activation_nudge.es.text.erb
@@ -1,0 +1,9 @@
+Tu clínica está lista.
+
+Agregar tu primer paciente es la mejor manera de ver cómo funciona Odonto.me — las citas, los recordatorios y los expedientes comienzan ahí. Solo toma un minuto. Agrega tu primer paciente en https://my.odonto.me/patients/new
+
+¿Dudas? Responde a este correo y te ayudamos a comenzar.
+
+--
+Gracias por unirte a nosotros,
+El equipo de Odonto.me

--- a/app/views/practice_mailer/activation_nudge.html.erb
+++ b/app/views/practice_mailer/activation_nudge.html.erb
@@ -1,0 +1,23 @@
+<tr>
+	<td class="content-block">
+		<h2>Your practice is ready.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Adding your first patient is the best way to see how Odonto.me works &mdash; appointments, reminders, and records all start there. It only takes a minute.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/patients/new" class="btn-primary">Add your first patient</a>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Questions? Just reply to this email and we'll help you get set up.
+	</td>
+</tr>

--- a/app/views/practice_mailer/activation_nudge.pt.html.erb
+++ b/app/views/practice_mailer/activation_nudge.pt.html.erb
@@ -1,0 +1,23 @@
+<tr>
+	<td class="content-block">
+		<h2>Sua clínica está pronta.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Adicionar seu primeiro paciente é a melhor maneira de ver como o Odonto.me funciona &mdash; as consultas, os lembretes e os prontuários começam aí. Leva só um minuto.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/patients/new" class="btn-primary">Adicionar meu primeiro paciente</a>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Dúvidas? Responda a este e-mail e ajudaremos você a começar.
+	</td>
+</tr>

--- a/app/views/practice_mailer/activation_nudge.pt.text.erb
+++ b/app/views/practice_mailer/activation_nudge.pt.text.erb
@@ -1,0 +1,9 @@
+Sua clínica está pronta.
+
+Adicionar seu primeiro paciente é a melhor maneira de ver como o Odonto.me funciona — as consultas, os lembretes e os prontuários começam aí. Leva só um minuto. Adicione seu primeiro paciente em https://my.odonto.me/patients/new
+
+Dúvidas? Responda a este e-mail e ajudaremos você a começar.
+
+--
+Obrigado por se inscrever,
+A equipe Odonto.me

--- a/app/views/practice_mailer/activation_nudge.text.erb
+++ b/app/views/practice_mailer/activation_nudge.text.erb
@@ -1,0 +1,9 @@
+Your practice is ready.
+
+Adding your first patient is the best way to see how Odonto.me works — appointments, reminders, and records all start there. It only takes a minute. Add your first patient at https://my.odonto.me/patients/new
+
+Questions? Just reply to this email and we'll help you get set up.
+
+--
+Thanks for signing up,
+The Odonto.me team

--- a/app/views/practice_mailer/deletion_warning.es.html.erb
+++ b/app/views/practice_mailer/deletion_warning.es.html.erb
@@ -1,0 +1,17 @@
+<tr>
+	<td class="content-block">
+		<h2>Estamos a punto de despedirnos.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Tu prueba terminó y tu cuenta aún no tiene pacientes, así que será eliminada en los próximos días. Si quieres conservarla, subscribirte toma solo un minuto &mdash; o responde a este correo y con gusto te ayudamos a comenzar.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/practice/settings" class="btn-primary">Conservar mi cuenta</a>
+	</td>
+</tr>

--- a/app/views/practice_mailer/deletion_warning.es.text.erb
+++ b/app/views/practice_mailer/deletion_warning.es.text.erb
@@ -1,0 +1,7 @@
+Estamos a punto de despedirnos.
+
+Tu prueba terminó y tu cuenta aún no tiene pacientes, así que será eliminada en los próximos días. Si quieres conservarla, subscribirte toma solo un minuto — o responde a este correo y con gusto te ayudamos a comenzar. Conserva tu cuenta en https://my.odonto.me/practice/settings
+
+--
+Gracias por unirte a nosotros,
+El equipo de Odonto.me

--- a/app/views/practice_mailer/deletion_warning.html.erb
+++ b/app/views/practice_mailer/deletion_warning.html.erb
@@ -1,0 +1,17 @@
+<tr>
+	<td class="content-block">
+		<h2>We're about to say goodbye.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Your trial ended and your account has no patients yet, so it is scheduled to be deleted in the next few days. If you'd like to keep it, subscribing takes just a minute &mdash; or reply to this email and we'll gladly help you get started.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/practice/settings" class="btn-primary">Keep my account</a>
+	</td>
+</tr>

--- a/app/views/practice_mailer/deletion_warning.pt.html.erb
+++ b/app/views/practice_mailer/deletion_warning.pt.html.erb
@@ -1,0 +1,17 @@
+<tr>
+	<td class="content-block">
+		<h2>Estamos prestes a nos despedir.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Seu teste terminou e sua conta ainda não tem pacientes, então ela será excluída nos próximos dias. Se quiser mantê-la, assinar leva só um minuto &mdash; ou responda a este e-mail e teremos prazer em ajudar você a começar.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/practice/settings" class="btn-primary">Manter minha conta</a>
+	</td>
+</tr>

--- a/app/views/practice_mailer/deletion_warning.pt.text.erb
+++ b/app/views/practice_mailer/deletion_warning.pt.text.erb
@@ -1,0 +1,7 @@
+Estamos prestes a nos despedir.
+
+Seu teste terminou e sua conta ainda não tem pacientes, então ela será excluída nos próximos dias. Se quiser mantê-la, assinar leva só um minuto — ou responda a este e-mail e teremos prazer em ajudar você a começar. Mantenha sua conta em https://my.odonto.me/practice/settings
+
+--
+Obrigado por se inscrever,
+A equipe Odonto.me

--- a/app/views/practice_mailer/deletion_warning.text.erb
+++ b/app/views/practice_mailer/deletion_warning.text.erb
@@ -1,0 +1,7 @@
+We're about to say goodbye.
+
+Your trial ended and your account has no patients yet, so it is scheduled to be deleted in the next few days. If you'd like to keep it, subscribing takes just a minute — or reply to this email and we'll gladly help you get started. Keep your account at https://my.odonto.me/practice/settings
+
+--
+Thanks for signing up,
+The Odonto.me team

--- a/app/views/practice_mailer/trial_ended.es.html.erb
+++ b/app/views/practice_mailer/trial_ended.es.html.erb
@@ -1,0 +1,23 @@
+<tr>
+	<td class="content-block">
+		<h2>Tu prueba gratis ha terminado.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Tu cuenta está en pausa, pero todo sigue exactamente donde lo dejaste. Subscríbete por <%= @price %> al mes para continuar justo donde te quedaste. Tu información se guarda de forma segura por un tiempo limitado.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/practice/settings" class="btn-primary">Reactivar mi cuenta</a>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		¿Dudas? Responde a este correo.
+	</td>
+</tr>

--- a/app/views/practice_mailer/trial_ended.es.text.erb
+++ b/app/views/practice_mailer/trial_ended.es.text.erb
@@ -1,0 +1,9 @@
+Tu prueba gratis ha terminado.
+
+Tu cuenta está en pausa, pero todo sigue exactamente donde lo dejaste. Subscríbete por <%= @price %> al mes para continuar justo donde te quedaste. Tu información se guarda de forma segura por un tiempo limitado. Reactiva tu cuenta en https://my.odonto.me/practice/settings
+
+¿Dudas? Responde a este correo.
+
+--
+Gracias por unirte a nosotros,
+El equipo de Odonto.me

--- a/app/views/practice_mailer/trial_ended.html.erb
+++ b/app/views/practice_mailer/trial_ended.html.erb
@@ -1,0 +1,23 @@
+<tr>
+	<td class="content-block">
+		<h2>Your free trial has ended.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Your account is paused, but everything is exactly where you left it. Subscribe for <%= @price %> per month to pick up right where you left off. Your information is kept safe for a limited time.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/practice/settings" class="btn-primary">Reactivate my account</a>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Questions? Just reply to this email.
+	</td>
+</tr>

--- a/app/views/practice_mailer/trial_ended.pt.html.erb
+++ b/app/views/practice_mailer/trial_ended.pt.html.erb
@@ -1,0 +1,23 @@
+<tr>
+	<td class="content-block">
+		<h2>Seu teste grátis terminou.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Sua conta está pausada, mas tudo continua exatamente onde você deixou. Assine por <%= @price %> por mês para continuar de onde parou. Suas informações ficam guardadas com segurança por um tempo limitado.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/practice/settings" class="btn-primary">Reativar minha conta</a>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Dúvidas? Responda a este e-mail.
+	</td>
+</tr>

--- a/app/views/practice_mailer/trial_ended.pt.text.erb
+++ b/app/views/practice_mailer/trial_ended.pt.text.erb
@@ -1,0 +1,9 @@
+Seu teste grátis terminou.
+
+Sua conta está pausada, mas tudo continua exatamente onde você deixou. Assine por <%= @price %> por mês para continuar de onde parou. Suas informações ficam guardadas com segurança por um tempo limitado. Reative sua conta em https://my.odonto.me/practice/settings
+
+Dúvidas? Responda a este e-mail.
+
+--
+Obrigado por se inscrever,
+A equipe Odonto.me

--- a/app/views/practice_mailer/trial_ended.text.erb
+++ b/app/views/practice_mailer/trial_ended.text.erb
@@ -1,0 +1,9 @@
+Your free trial has ended.
+
+Your account is paused, but everything is exactly where you left it. Subscribe for <%= @price %> per month to pick up right where you left off. Your information is kept safe for a limited time. Reactivate your account at https://my.odonto.me/practice/settings
+
+Questions? Just reply to this email.
+
+--
+Thanks for signing up,
+The Odonto.me team

--- a/app/views/practice_mailer/trial_ending.es.html.erb
+++ b/app/views/practice_mailer/trial_ending.es.html.erb
@@ -1,0 +1,23 @@
+<tr>
+	<td class="content-block">
+		<h2>Tu prueba gratis termina el <%= @trial_ends_on %>.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Esperamos que Odonto.me haya hecho más fácil manejar tu clínica. Para conservar tu agenda, tus pacientes y los recordatorios después de tu prueba, subscríbete por <%= @price %> al mes &mdash; puedes cancelar cuando quieras.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/practice/settings" class="btn-primary">Subscribirme ahora</a>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		¿Dudas? Responde a este correo.
+	</td>
+</tr>

--- a/app/views/practice_mailer/trial_ending.es.text.erb
+++ b/app/views/practice_mailer/trial_ending.es.text.erb
@@ -1,0 +1,9 @@
+Tu prueba gratis termina el <%= @trial_ends_on %>.
+
+Esperamos que Odonto.me haya hecho más fácil manejar tu clínica. Para conservar tu agenda, tus pacientes y los recordatorios después de tu prueba, subscríbete por <%= @price %> al mes — puedes cancelar cuando quieras. Subscríbete ahora en https://my.odonto.me/practice/settings
+
+¿Dudas? Responde a este correo.
+
+--
+Gracias por unirte a nosotros,
+El equipo de Odonto.me

--- a/app/views/practice_mailer/trial_ending.html.erb
+++ b/app/views/practice_mailer/trial_ending.html.erb
@@ -1,0 +1,23 @@
+<tr>
+	<td class="content-block">
+		<h2>Your free trial ends on <%= @trial_ends_on %>.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		We hope Odonto.me has made running your practice easier. To keep your calendar, patients, and reminders going after your trial, subscribe for <%= @price %> per month &mdash; cancel anytime.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/practice/settings" class="btn-primary">Subscribe now</a>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Questions? Just reply to this email.
+	</td>
+</tr>

--- a/app/views/practice_mailer/trial_ending.pt.html.erb
+++ b/app/views/practice_mailer/trial_ending.pt.html.erb
@@ -1,0 +1,23 @@
+<tr>
+	<td class="content-block">
+		<h2>Seu teste grátis termina em <%= @trial_ends_on %>.</h2>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Esperamos que o Odonto.me tenha facilitado a gestão da sua clínica. Para manter sua agenda, seus pacientes e os lembretes depois do teste, assine por <%= @price %> por mês &mdash; cancele quando quiser.
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		<a href="https://my.odonto.me/practice/settings" class="btn-primary">Assinar agora</a>
+	</td>
+</tr>
+
+<tr>
+	<td class="content-block">
+		Dúvidas? Responda a este e-mail.
+	</td>
+</tr>

--- a/app/views/practice_mailer/trial_ending.pt.text.erb
+++ b/app/views/practice_mailer/trial_ending.pt.text.erb
@@ -1,0 +1,9 @@
+Seu teste grátis termina em <%= @trial_ends_on %>.
+
+Esperamos que o Odonto.me tenha facilitado a gestão da sua clínica. Para manter sua agenda, seus pacientes e os lembretes depois do teste, assine por <%= @price %> por mês — cancele quando quiser. Assine agora em https://my.odonto.me/practice/settings
+
+Dúvidas? Responda a este e-mail.
+
+--
+Obrigado por se inscrever,
+A equipe Odonto.me

--- a/app/views/practice_mailer/trial_ending.text.erb
+++ b/app/views/practice_mailer/trial_ending.text.erb
@@ -1,0 +1,9 @@
+Your free trial ends on <%= @trial_ends_on %>.
+
+We hope Odonto.me has made running your practice easier. To keep your calendar, patients, and reminders going after your trial, subscribe for <%= @price %> per month — cancel anytime. Subscribe now at https://my.odonto.me/practice/settings
+
+Questions? Just reply to this email.
+
+--
+Thanks for signing up,
+The Odonto.me team

--- a/app/views/practices/settings.html.erb
+++ b/app/views/practices/settings.html.erb
@@ -30,10 +30,13 @@
             </div>
 
             <div class="card-body">
-              <% if !@practice.has_linked_subscription? && @practice.has_active_subscription? %>
-                <%= raw t('subscriptions.message_to_admin.trialing', stripe_url: link_to(t('subscriptions.cta.trialing'), subscriptions_url, method: :post).html_safe) %>
+              <% if @subscription.is_trialing? && !@subscription.is_trial_expired? %>
+                <p><%= t('subscriptions.message_to_admin.trialing_intro', days: @subscription.days_to_next_payment) %></p>
+                <p><%= raw t('subscriptions.message_to_admin.trialing', price: Rails.configuration.stripe[:price_display], stripe_url: link_to(t('subscriptions.cta.trialing'), subscriptions_url, method: :post).html_safe) %></p>
               <% elsif @practice.has_linked_subscription? && @practice.has_active_subscription? %>
                 <%= raw t('subscriptions.message_to_admin.active', status: @subscription.status, stripe_url: link_to(t('subscriptions.cta.active'), subscriptions_url, method: :put).html_safe) %>
+              <% elsif @subscription.status == 'past_due' %>
+                <%= raw t('subscriptions.message_to_admin.past_due', stripe_url: link_to(t('subscriptions.cta.active'), subscriptions_url, method: :put).html_safe) %>
               <% else %>
                 <%= raw t('subscriptions.message_to_admin.expired', stripe_url: link_to(t('subscriptions.cta.expired'), subscriptions_url, method: :post).html_safe) %>
               <% end %>

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -8,7 +8,8 @@ stripe_config = begin
     publishable_key: secrets['stripe_publishable_key'],
     secret_key: secrets['stripe_secret_key'],
     webhook_secret: secrets['stripe_webhook_secret'],
-    price_id: secrets['stripe_price_id']
+    price_id: secrets['stripe_price_id'],
+    price_display: secrets['stripe_price_display'] || ENV['STRIPE_PRICE_DISPLAY'] || '$6 USD'
   }
 rescue StandardError
   # Fallback to environment variables
@@ -16,7 +17,8 @@ rescue StandardError
     publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'],
     secret_key: ENV['STRIPE_SECRET_KEY'],
     webhook_secret: ENV['STRIPE_WEBHOOK_SECRET'],
-    price_id: ENV['STRIPE_PRICE_ID']
+    price_id: ENV['STRIPE_PRICE_ID'],
+    price_display: ENV['STRIPE_PRICE_DISPLAY'] || '$6 USD'
   }
 end
 
@@ -24,7 +26,8 @@ Rails.configuration.stripe = {
   publishable_key: stripe_config[:publishable_key],
   secret_key: stripe_config[:secret_key],
   webhook_secret: stripe_config[:webhook_secret],
-  price_id: stripe_config[:price_id]
+  price_id: stripe_config[:price_id],
+  price_display: stripe_config[:price_display]
 }
 
 Stripe.api_key = Rails.configuration.stripe[:secret_key]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,6 +308,14 @@ en:
     practice:
       welcome:
         subject: Welcome to Odonto.me
+      activation_nudge:
+        subject: Ready when you are — add your first patient
+      trial_ending:
+        subject: Your free trial ends soon
+      trial_ended:
+        subject: Your free trial has ended
+      deletion_warning:
+        subject: Your Odonto.me account will be deleted soon
       daily_recap:
         subject: Daily recap for %{date}
       new_review_notification:
@@ -474,7 +482,9 @@ en:
     message_to_admin:
       active: Your subscription is %{status}, you can %{stripe_url} at any time.
       expired: Your subscription is no longer active, please %{stripe_url} to activate your account.
-      trialing: This is a trial subcription, please %{stripe_url} before your trial period ends.
+      past_due: Your last payment didn't go through. Please %{stripe_url} to update your billing details.
+      trialing_intro: You have %{days} days left in your free trial.
+      trialing: After that, it's %{price} per month — %{stripe_url} whenever you're ready, and cancel anytime.
     errors:
       expiring: Your subscription will expire soon. Please <a href="%{practice_settings_url}">subscribe</a> in order to keep access to your account.
       expired: Your subscription has expired, please renew it to regain access to your account.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -291,6 +291,14 @@ es:
     practice:
       welcome:
         subject: Bienvenido a Odonto.me
+      activation_nudge:
+        subject: Cuando quieras — agrega tu primer paciente
+      trial_ending:
+        subject: Tu prueba gratis termina pronto
+      trial_ended:
+        subject: Tu prueba gratis ha terminado
+      deletion_warning:
+        subject: Tu cuenta de Odonto.me será eliminada pronto
       daily_recap:
         subject: Resumen diario de %{date}
       new_review_notification:
@@ -426,7 +434,9 @@ es:
     message_to_admin:
       active: Tu subscripción esta activa, puedes %{stripe_url} en cualquier momento.
       expired: Tu subscripción ha expirado, por favor %{stripe_url} para reactivar tu cuenta.
-      trialing: Estás usando una subscripción de prueba, por favor %{stripe_url} para activarla.
+      past_due: Tu último pago no se pudo procesar. Por favor %{stripe_url} para actualizar tus datos de pago.
+      trialing_intro: Te quedan %{days} días de tu prueba gratis.
+      trialing: Después, cuesta %{price} al mes — %{stripe_url} cuando estés listo, y puedes cancelar cuando quieras.
     errors:
       expiring: Tu subscripción va a expirar pronto. Por favor <a href="%{practice_settings_url}">subscríbete</a> para no perder acceso a tu cuenta.
       expired: Tu subscripción ha expirado, por favor renueva la subscripción para obtener acceso a tu cuenta.

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -303,6 +303,14 @@ pt:
     practice:
       welcome:
         subject: Bem-vindo ao Odonto.me
+      activation_nudge:
+        subject: Quando quiser — adicione seu primeiro paciente
+      trial_ending:
+        subject: Seu teste grátis termina em breve
+      trial_ended:
+        subject: Seu teste grátis terminou
+      deletion_warning:
+        subject: Sua conta do Odonto.me será excluída em breve
       daily_recap:
         subject: Resumo diário para %{date}
       new_review_notification:
@@ -465,7 +473,9 @@ pt:
     message_to_admin:
       active: Sua assinatura está %{status}, você pode %{stripe_url} a qualquer momento.
       expired: Sua assinatura não está mais ativa, por favor %{stripe_url} para ativar sua conta.
-      trialing: Esta é uma assinatura de teste, por favor %{stripe_url} antes que seu período de teste termine.
+      past_due: Seu último pagamento não foi processado. Por favor %{stripe_url} para atualizar seus dados de pagamento.
+      trialing_intro: Você tem %{days} dias restantes no seu teste grátis.
+      trialing: Depois, custa %{price} por mês — %{stripe_url} quando estiver pronto, e cancele quando quiser.
     errors:
       expiring: Sua assinatura expirará em breve. Por favor <a href="%{practice_settings_url}">assine</a> para manter o acesso à sua conta.
       expired: Sua assinatura expirou, por favor renove-a para recuperar o acesso à sua conta.

--- a/db/migrate/20260728000001_add_lifecycle_notification_flags_to_practices.rb
+++ b/db/migrate/20260728000001_add_lifecycle_notification_flags_to_practices.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddLifecycleNotificationFlagsToPractices < ActiveRecord::Migration[8.1]
+  def change
+    add_column :practices, :notified_of_activation_nudge, :boolean, default: false, null: false
+    add_column :practices, :notified_of_trial_ending, :boolean, default: false, null: false
+    add_column :practices, :notified_of_trial_ended, :boolean, default: false, null: false
+    add_column :practices, :notified_of_deletion_warning, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_21_230000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_28_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -155,6 +155,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_21_230000) do
     t.string "email"
     t.string "locale", default: "en_US"
     t.string "name"
+    t.boolean "notified_of_activation_nudge", default: false, null: false
+    t.boolean "notified_of_deletion_warning", default: false, null: false
+    t.boolean "notified_of_trial_ended", default: false, null: false
+    t.boolean "notified_of_trial_ending", default: false, null: false
     t.integer "patients_count", default: 0
     t.text "stripe_account_id"
     t.text "stripe_customer_id"

--- a/lib/tasks/odontome.rake
+++ b/lib/tasks/odontome.rake
@@ -232,13 +232,15 @@ namespace :odontome do
     Rails.logger.info "Cleaned up #{deleted_count} audit log entries older than #{cutoff_date.strftime('%Y-%m-%d')}"
   end
 
-  desc 'Cleanup practices older than 7 days with 0 patients'
+  desc 'Cleanup practices older than 40 days with 0 patients (deletion warning goes out at day 37)'
   task cleanup_old_practices: :environment do
     Rails.logger = Logger.new($stdout) if defined?(Rails) && (Rails.env == 'development')
 
-    cutoff_date = 7.days.ago
-    practices = Practice.where('created_at < ?', cutoff_date)
-                        .where('patients_count = ?', 0)
+    cutoff_date = 40.days.ago
+    practices = Practice.left_joins(:subscription)
+                        .where('practices.created_at < ?', cutoff_date)
+                        .where(patients_count: 0)
+                        .where.not(subscriptions: { status: %w[active past_due] })
     deleted_count = practices.destroy_all
 
     Rails.logger.info "Cleaned up #{deleted_count} practices older than #{cutoff_date.strftime('%Y-%m-%d')} with 0 patients"
@@ -268,6 +270,23 @@ namespace :odontome do
     Rails.logger.info "Marked #{marked_count} inactive practices for cancellation (trialing > 60 days)"
   end
 
+  desc 'Practice lifecycle emails hub: activation nudge, trial ending, trial ended, deletion warning'
+  task practice_lifecycle: :environment do
+    Rails.logger = Logger.new($stdout) if defined?(Rails) && (Rails.env == 'development')
+
+    # Consider practices where local time is mid-morning to avoid odd-hour sends
+    hour_to_send_emails = 10
+    timezones_where_hour_is = timezones_where_hour_are(hour_to_send_emails)
+    practice_ids = practices_in_timezones(timezones_where_hour_is)
+
+    next if practice_ids.empty?
+
+    send_activation_nudges(practice_ids)
+    send_trial_ending_notices(practice_ids)
+    send_trial_ended_notices(practice_ids)
+    send_deletion_warnings(practice_ids)
+  end
+
   def disable_parallel_workers
     ActiveRecord::Base.connection.execute('SET max_parallel_workers_per_gather = 0')
   end
@@ -287,9 +306,13 @@ namespace :odontome do
   def practices_in_timezones(timezones)
     return [] if timezones.empty?
 
+    # Practices store either Rails-friendly names ("London") or IANA
+    # identifiers ("Europe/London") depending on signup path — match both.
+    timezone_names = timezones.flat_map { |name| [name, ActiveSupport::TimeZone::MAPPING[name]] }.compact.uniq
+
     # Only include practices that are active or trialing, and not cancelled
     Practice.joins(:subscription)
-            .where(timezone: timezones)
+            .where(timezone: timezone_names)
             .where(subscriptions: { status: %w[trialing active] })
             .pluck(:id)
   end
@@ -301,5 +324,63 @@ namespace :odontome do
         .where('roles = ?', 'admin')
         .joins(:practice)
         .order(:practice_id)
+  end
+
+  # a practice is only eligible for lifecycle emails while it is
+  # trialing, not cancelled, and hasn't received that email before
+  def trialing_practices_for_lifecycle(practice_ids, notified_flag)
+    Practice.joins(:subscription).includes(:subscription)
+            .where(id: practice_ids, cancelled_at: nil, notified_flag => false)
+            .where(subscriptions: { status: 'trialing' })
+  end
+
+  def send_activation_nudges(practice_ids)
+    practices = trialing_practices_for_lifecycle(practice_ids, :notified_of_activation_nudge)
+                .where(patients_count: 0)
+                .where(created_at: 5.days.ago..2.days.ago)
+
+    practices.find_each do |practice|
+      PracticeMailer.activation_nudge(practice).deliver_now
+      practice.update_column(:notified_of_activation_nudge, true)
+    rescue StandardError => e
+      Rails.logger.error "practice_lifecycle: activation_nudge failed for practice #{practice.id}: #{e.message}"
+    end
+  end
+
+  def send_trial_ending_notices(practice_ids)
+    practices = trialing_practices_for_lifecycle(practice_ids, :notified_of_trial_ending)
+                .where(subscriptions: { current_period_end: 1.day.from_now..5.days.from_now })
+
+    practices.find_each do |practice|
+      PracticeMailer.trial_ending(practice).deliver_now
+      practice.update_column(:notified_of_trial_ending, true)
+    rescue StandardError => e
+      Rails.logger.error "practice_lifecycle: trial_ending failed for practice #{practice.id}: #{e.message}"
+    end
+  end
+
+  def send_trial_ended_notices(practice_ids)
+    practices = trialing_practices_for_lifecycle(practice_ids, :notified_of_trial_ended)
+                .where(subscriptions: { current_period_end: 4.days.ago..Time.now })
+
+    practices.find_each do |practice|
+      PracticeMailer.trial_ended(practice).deliver_now
+      practice.update_column(:notified_of_trial_ended, true)
+    rescue StandardError => e
+      Rails.logger.error "practice_lifecycle: trial_ended failed for practice #{practice.id}: #{e.message}"
+    end
+  end
+
+  def send_deletion_warnings(practice_ids)
+    practices = trialing_practices_for_lifecycle(practice_ids, :notified_of_deletion_warning)
+                .where(patients_count: 0)
+                .where(created_at: ..37.days.ago)
+
+    practices.find_each do |practice|
+      PracticeMailer.deletion_warning(practice).deliver_now
+      practice.update_column(:notified_of_deletion_warning, true)
+    rescue StandardError => e
+      Rails.logger.error "practice_lifecycle: deletion_warning failed for practice #{practice.id}: #{e.message}"
+    end
   end
 end

--- a/test/functional/application_controller_test.rb
+++ b/test/functional/application_controller_test.rb
@@ -20,4 +20,13 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_select '.alert.alert-warning .text-muted', text: /Your subscription will expire soon/
     assert_includes response.body, expected_warning
   end
+
+  test 'does not show expiring banner more than 7 days before trial end' do
+    users(:founder).practice.subscription.update_columns(current_period_end: 8.days.from_now)
+
+    get :index
+
+    assert_response :success
+    assert_nil flash[:warning]
+  end
 end

--- a/test/functional/practices_controller_test.rb
+++ b/test/functional/practices_controller_test.rb
@@ -7,6 +7,10 @@ class PracticesControllerTest < ActionController::TestCase
     @controller.session['user'] = users(:founder)
   end
 
+  teardown do
+    I18n.locale = I18n.default_locale
+  end
+
   test 'should get new' do
     @controller.session['user'] = nil
     get :new
@@ -72,6 +76,51 @@ class PracticesControllerTest < ActionController::TestCase
       post :create, params: { practice: practice, consent_terms: '1', consent_privacy: '1' }
     end
     assert_equal Practice.last.email, 'demo@odonto.me'
+  end
+
+  test 'signup page renders in Spanish for Spanish browsers' do
+    @controller.session['user'] = nil
+    @request.headers['Accept-Language'] = 'es-MX,es;q=0.9,en;q=0.8'
+
+    get :new
+
+    assert_response :success
+    assert_equal :es, I18n.locale
+  end
+
+  test 'should create practice with locale detected from browser' do
+    @controller.session['user'] = nil
+    @request.headers['Accept-Language'] = 'es-MX,es;q=0.9,en;q=0.8'
+
+    practice = { name: 'Clinica Demo',
+                 timezone: 'America/Mexico_City',
+                 users_attributes: { '0' => { 'email' => 'demo-es@odonto.me', 'password' => '1234567890',
+                                              'password_confirmation' => '1234567890' } } }
+
+    assert_difference('Practice.count') do
+      post :create, params: { practice: practice, consent_terms: '1', consent_privacy: '1' }
+    end
+
+    assert_equal 'es', Practice.last.locale
+
+    welcome_email = ActionMailer::Base.deliveries.last
+    assert_equal I18n.t('mailers.practice.welcome.subject', locale: :es), welcome_email.subject
+  end
+
+  test 'should create practice with English locale for unsupported browser language' do
+    @controller.session['user'] = nil
+    @request.headers['Accept-Language'] = 'de-DE,de;q=0.9'
+
+    practice = { name: 'Deutsche Praxis',
+                 timezone: 'Europe/London',
+                 users_attributes: { '0' => { 'email' => 'demo-de@odonto.me', 'password' => '1234567890',
+                                              'password_confirmation' => '1234567890' } } }
+
+    assert_difference('Practice.count') do
+      post :create, params: { practice: practice, consent_terms: '1', consent_privacy: '1' }
+    end
+
+    assert_equal 'en', Practice.last.locale
   end
 
   test 'should update practice with custom review URL' do
@@ -168,5 +217,35 @@ class PracticesControllerTest < ActionController::TestCase
     get :show, params: { id: practices(:complete).to_param }
     assert_response :redirect
     assert_redirected_to signin_path
+  end
+
+  test 'settings shows trial copy with days left and price while trialing' do
+    users(:founder).practice.subscription.update_columns(status: 'trialing',
+                                                          current_period_end: 20.days.from_now)
+
+    get :settings
+
+    assert_response :success
+    assert_match I18n.t('subscriptions.message_to_admin.trialing_intro', days: 20), response.body
+    assert_match Rails.configuration.stripe[:price_display], response.body
+  end
+
+  test 'settings shows expired copy after trial ends' do
+    users(:founder).practice.subscription.update_columns(status: 'trialing',
+                                                          current_period_end: 1.day.ago)
+
+    get :settings
+
+    assert_response :success
+    assert_match(/no longer active/, response.body)
+  end
+
+  test 'settings shows past due copy when payment failed' do
+    users(:founder).practice.subscription.update_columns(status: 'past_due')
+
+    get :settings
+
+    assert_response :success
+    assert_match(/update your billing details/, response.body)
   end
 end

--- a/test/functional/practices_controller_test.rb
+++ b/test/functional/practices_controller_test.rb
@@ -220,14 +220,18 @@ class PracticesControllerTest < ActionController::TestCase
   end
 
   test 'settings shows trial copy with days left and price while trialing' do
-    users(:founder).practice.subscription.update_columns(status: 'trialing',
-                                                          current_period_end: 20.days.from_now)
+    # Freeze at mid-day UTC: near midnight the practice timezone is already on
+    # the next date, which shifts days_to_next_payment by one and flakes CI
+    travel_to Time.utc(2026, 8, 15, 12, 0, 0) do
+      users(:founder).practice.subscription.update_columns(status: 'trialing',
+                                                            current_period_end: 20.days.from_now)
 
-    get :settings
+      get :settings
 
-    assert_response :success
-    assert_match I18n.t('subscriptions.message_to_admin.trialing_intro', days: 20), response.body
-    assert_match Rails.configuration.stripe[:price_display], response.body
+      assert_response :success
+      assert_match I18n.t('subscriptions.message_to_admin.trialing_intro', days: 20), response.body
+      assert_match Rails.configuration.stripe[:price_display], response.body
+    end
   end
 
   test 'settings shows expired copy after trial ends' do

--- a/test/mailers/practice_mailer_test.rb
+++ b/test/mailers/practice_mailer_test.rb
@@ -25,6 +25,53 @@ class PracticeMailerTest < ActionMailer::TestCase
     assert_match(/Welcome to Odonto.me/, email.encoded)
   end
 
+  test 'activation nudge email' do
+    practice = practices(:complete_another_language) # locale: es
+
+    email = PracticeMailer.activation_nudge(practice)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal ['hello@odonto.me'], email.from
+    assert_equal [practice.email], email.to
+    assert_equal I18n.t('mailers.practice.activation_nudge.subject', locale: :es), email.subject
+    assert_match(%r{https://my.odonto.me/patients/new}, email.encoded)
+  end
+
+  test 'trial ending email includes date and price' do
+    practice = practices(:trialing_practice)
+
+    email = PracticeMailer.trial_ending(practice)
+
+    assert_equal [practice.email], email.to
+    assert_equal I18n.t('mailers.practice.trial_ending.subject'), email.subject
+    assert_match practice.subscription.current_period_end.strftime('%d/%m/%Y'), email.encoded
+    assert_match(/\$6 USD/, email.encoded)
+    assert_match(%r{https://my.odonto.me/practice/settings}, email.encoded)
+  end
+
+  test 'trial ended email' do
+    practice = practices(:trialing_practice)
+
+    email = PracticeMailer.trial_ended(practice)
+
+    assert_equal [practice.email], email.to
+    assert_equal I18n.t('mailers.practice.trial_ended.subject'), email.subject
+    assert_match(%r{https://my.odonto.me/practice/settings}, email.encoded)
+  end
+
+  test 'deletion warning email' do
+    practice = practices(:trialing_practice)
+
+    email = PracticeMailer.deletion_warning(practice)
+
+    assert_equal [practice.email], email.to
+    assert_equal I18n.t('mailers.practice.deletion_warning.subject'), email.subject
+    assert_match(%r{https://my.odonto.me/practice/settings}, email.encoded)
+  end
+
   test 'new_review_notification' do
     review = reviews(:valid)
     practice = review.appointment.datebook.practice

--- a/test/mailers/previews/practice_mailer_preview.rb
+++ b/test/mailers/previews/practice_mailer_preview.rb
@@ -2,6 +2,34 @@
 
 # Preview all emails at http://localhost:3000/rails/mailers/practice_mailer
 class PracticeMailerPreview < ActionMailer::Preview
+  def activation_nudge
+    practice = Practice.last
+    raise 'Create a Practice record in development to preview this email.' unless practice
+
+    PracticeMailer.activation_nudge practice
+  end
+
+  def trial_ending
+    practice = Practice.last
+    raise 'Create a Practice record in development to preview this email.' unless practice
+
+    PracticeMailer.trial_ending practice
+  end
+
+  def trial_ended
+    practice = Practice.last
+    raise 'Create a Practice record in development to preview this email.' unless practice
+
+    PracticeMailer.trial_ended practice
+  end
+
+  def deletion_warning
+    practice = Practice.last
+    raise 'Create a Practice record in development to preview this email.' unless practice
+
+    PracticeMailer.deletion_warning practice
+  end
+
   def new_review_notification
     review = Review.last
     raise 'Create a Review record in development to preview this email.' unless review

--- a/test/unit/models/subscription_test.rb
+++ b/test/unit/models/subscription_test.rb
@@ -42,4 +42,18 @@ class SubscriptionTest < ActiveSupport::TestCase
     past_due = subscriptions(:past_due)
     assert past_due.active_or_trialing?
   end
+
+  test 'trial is expiring inside 7 days' do
+    subscription = subscriptions(:trialing)
+    subscription.update_columns(current_period_end: 6.days.from_now)
+
+    assert subscription.is_trial_expiring?
+  end
+
+  test 'trial is not expiring outside 7 days' do
+    subscription = subscriptions(:trialing)
+    subscription.update_columns(current_period_end: 8.days.from_now)
+
+    refute subscription.is_trial_expiring?
+  end
 end

--- a/test/unit/tasks/cleanup_old_practices_task_test.rb
+++ b/test/unit/tasks/cleanup_old_practices_task_test.rb
@@ -5,17 +5,34 @@ require 'test_helper'
 class CleanupOldPractices < RakeTaskTestCase
   rake_task 'odontome:cleanup_old_practices'
 
-  test 'removes practices older than 7 days with 0 patients' do
+  test 'removes practices older than 40 days with 0 patients' do
     practice = practices(:trialing_practice)
-    practice.update_columns(created_at: 8.days.ago, patients_count: 0)
+    practice.update_columns(created_at: 41.days.ago, patients_count: 0)
 
     @task.invoke
     assert_equal 0, Practice.where(id: practice.id).count
   end
 
+  test 'does not remove practices still in or shortly after their trial' do
+    practice = practices(:trialing_practice)
+    practice.update_columns(created_at: 39.days.ago, patients_count: 0)
+
+    @task.invoke
+    assert_equal 1, Practice.where(id: practice.id).count
+  end
+
   test 'does not remove practices with patients' do
     practice = practices(:trialing_practice)
-    practice.update_columns(created_at: 12.days.ago, patients_count: 1)
+    practice.update_columns(created_at: 60.days.ago, patients_count: 1)
+
+    @task.invoke
+    assert_equal 1, Practice.where(id: practice.id).count
+  end
+
+  test 'does not remove 0-patient practices with an active subscription' do
+    practice = practices(:trialing_practice)
+    practice.update_columns(created_at: 60.days.ago, patients_count: 0)
+    practice.subscription.update_columns(status: 'active')
 
     @task.invoke
     assert_equal 1, Practice.where(id: practice.id).count

--- a/test/unit/tasks/practice_lifecycle_task_test.rb
+++ b/test/unit/tasks/practice_lifecycle_task_test.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PracticeLifecycleTaskTest < RakeTaskTestCase
+  rake_task 'odontome:practice_lifecycle'
+
+  def setup
+    super
+    travel_to Time.utc(2025, 1, 15, 10, 0, 0) # 10am in Europe/London
+    ActionMailer::Base.deliveries.clear
+
+    # practices(:trialing_practice) keeps its fixture timezone of "Europe/London"
+    # (the real-world IANA identifier signup produces) on purpose: practices_in_timezones
+    # now expands friendly names ("London") through ActiveSupport::TimeZone::MAPPING to
+    # also match IANA identifiers, so this fixture matching the 10am-local gate as-is is
+    # itself the regression test for that fix.
+  end
+
+  def teardown
+    travel_back
+    super
+  end
+
+  def practice
+    @practice ||= practices(:trialing_practice)
+  end
+
+  test 'sends activation nudge to 3-day-old practices with no patients' do
+    practice.update_columns(created_at: 3.days.ago, patients_count: 0)
+
+    assert_difference -> { ActionMailer::Base.deliveries.count }, 1 do
+      @task.invoke
+    end
+
+    assert practice.reload.notified_of_activation_nudge
+    email = ActionMailer::Base.deliveries.last
+    assert_equal I18n.t('mailers.practice.activation_nudge.subject'), email.subject
+  end
+
+  test 'does not send activation nudge twice' do
+    practice.update_columns(created_at: 3.days.ago, patients_count: 0,
+                            notified_of_activation_nudge: true)
+
+    @task.invoke
+
+    assert_empty ActionMailer::Base.deliveries
+  end
+
+  test 'does not send activation nudge to practices with patients' do
+    practice.update_columns(created_at: 3.days.ago, patients_count: 1)
+
+    @task.invoke
+
+    assert_empty ActionMailer::Base.deliveries
+  end
+
+  test 'does not send activation nudge outside the send window' do
+    practice.update_columns(created_at: 1.day.ago, patients_count: 0)
+
+    @task.invoke
+
+    assert_empty ActionMailer::Base.deliveries
+  end
+
+  test 'sends trial ending notice when trial ends within 5 days' do
+    practice.update_columns(created_at: 26.days.ago, patients_count: 1)
+    practice.subscription.update_columns(current_period_end: 4.days.from_now)
+
+    assert_difference -> { ActionMailer::Base.deliveries.count }, 1 do
+      @task.invoke
+    end
+
+    assert practice.reload.notified_of_trial_ending
+    assert_equal I18n.t('mailers.practice.trial_ending.subject'),
+                 ActionMailer::Base.deliveries.last.subject
+  end
+
+  test 'does not send trial ending notice to active subscriptions' do
+    other = practices(:complete)
+    other.subscription.update_columns(status: 'active', current_period_end: 4.days.from_now)
+
+    @task.invoke
+
+    refute ActionMailer::Base.deliveries.map(&:subject)
+                             .include?(I18n.t('mailers.practice.trial_ending.subject'))
+  end
+
+  test 'sends trial ended notice the day after expiry' do
+    practice.update_columns(created_at: 31.days.ago, patients_count: 1)
+    practice.subscription.update_columns(current_period_end: 1.day.ago)
+
+    assert_difference -> { ActionMailer::Base.deliveries.count }, 1 do
+      @task.invoke
+    end
+
+    assert practice.reload.notified_of_trial_ended
+    assert_equal I18n.t('mailers.practice.trial_ended.subject'),
+                 ActionMailer::Base.deliveries.last.subject
+  end
+
+  test 'sends deletion warning to 37-day-old practices with no patients' do
+    practice.update_columns(created_at: 37.days.ago, patients_count: 0,
+                            notified_of_activation_nudge: true)
+    practice.subscription.update_columns(current_period_end: 7.days.ago)
+
+    # trial_ended (window passed) must not fire; only deletion warning
+    assert_difference -> { ActionMailer::Base.deliveries.count }, 1 do
+      @task.invoke
+    end
+
+    assert practice.reload.notified_of_deletion_warning
+    assert_equal I18n.t('mailers.practice.deletion_warning.subject'),
+                 ActionMailer::Base.deliveries.last.subject
+  end
+
+  test 'sends nothing outside the 10am local window' do
+    travel_to Time.utc(2025, 1, 15, 20, 0, 0) # 8pm in London
+    practice.update_columns(created_at: 3.days.ago, patients_count: 0)
+
+    @task.invoke
+
+    assert_empty ActionMailer::Base.deliveries
+  end
+
+  test 'skips cancelled practices' do
+    practice.update_columns(created_at: 3.days.ago, patients_count: 0,
+                            cancelled_at: Time.now)
+
+    @task.invoke
+
+    assert_empty ActionMailer::Base.deliveries
+  end
+
+  test 'isolates a failed delivery so other eligible practices still get notified' do
+    first = practice # practices(:trialing_practice)
+    second = practices(:complete) # also trialing, eligible for activation nudge
+
+    first.update_columns(created_at: 3.days.ago, patients_count: 0)
+    second.update_columns(created_at: 3.days.ago, patients_count: 0)
+
+    PracticeMailer.stub(:activation_nudge, ->(p) { raise 'boom' if p.id == first.id; PracticeMailer.welcome_email(p) }) do
+      @task.invoke
+    end
+
+    refute first.reload.notified_of_activation_nudge
+    assert second.reload.notified_of_activation_nudge
+    assert_equal 1, ActionMailer::Base.deliveries.count
+  end
+end


### PR DESCRIPTION
Zero trial-to-paid conversions in 3 months: new practices were hard-coded to English, never emailed after signup, silently deleted at day 7, and shown 'subscription no longer active' while trialing.

## Changes

- Detect the browser language (es/pt/en) on logged-out pages and assign it to new practices
- Add four trial lifecycle emails in all three languages, sent by a single hourly `odontome:practice_lifecycle` task (self-gates to 10am local, send-once flags): day-2 nudge, day-25 trial ending with price, day-31 trial ended, day-37 deletion warning
- Delete 0-patient practices at day 40 instead of 7 — always warned first, never if subscribed
- Settings card now shows days left and price (`STRIPE_PRICE_DISPLAY`, default $6 USD); expiring banner only in the last 7 days; proper past_due copy
- Fix `practices_in_timezones` to also match IANA timezone ids — birthday/checkup/agenda emails were silently skipping web signups

## Deploy

Add the scheduler job `rake odontome:practice_lifecycle` (every hour). Migration runs on release as usual.

## Tests

483 runs, 2005 assertions, 0 failures. Signup, settings, and all four emails also verified in the running app (en + es).