### PR TITLE
feat(onboarding): guide new practices to their first doctor and patient

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -143,7 +143,8 @@ class PatientsController < ApplicationController
     params[:segment] == 'all' ||
       params[:letter].present? ||
       params[:sort].present? ||
-      params[:cursor].present?
+      params[:cursor].present? ||
+      (params[:segment].blank? && current_user.practice.patients_count.to_i.zero?)
   end
 
   def birthday_this_week_count

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -21,6 +21,7 @@ class WelcomeController < ApplicationController
 
   def determine_home_url
     return practices_admin_url if current_user_is_superadmin?
+    return practice_url if user_is_admin? && practice_needs_setup?
 
     # Always attempt to send the user back to their most relevant datebook
     home_datebook = last_visited_datebook || first_available_datebook
@@ -31,6 +32,12 @@ class WelcomeController < ApplicationController
     return new_datebook_url if user_is_admin?
 
     patients_url
+  end
+
+  def practice_needs_setup?
+    practice = current_user.practice
+
+    practice.doctors_count.to_i.zero? || practice.patients_count.to_i.zero?
   end
 
   def last_visited_datebook

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -27,7 +27,7 @@ class Practice < ApplicationRecord
   # callbacks
   before_validation :set_timezone_and_locale, on: :create
   before_validation :set_first_user_data, on: :create
-  after_create :create_first_datebook, :create_trial_subscription
+  after_create :create_first_datebook, :create_trial_subscription, :populate_default_treatments
   before_create :set_email_practice
 
   def set_as_cancelled
@@ -43,6 +43,8 @@ class Practice < ApplicationRecord
   end
 
   def populate_default_treatments
+    return if treatments.exists?
+
     locale_key = locale.presence || 'en'
     treatments_config = Rails.configuration.patient_treatments[locale_key] || Rails.configuration.patient_treatments['en']
     return unless treatments_config

--- a/app/views/doctors/index.html.erb
+++ b/app/views/doctors/index.html.erb
@@ -19,9 +19,9 @@
 <div class="page-body">
   <div class="card">
     <% if @doctors.empty? %>
-      <div class="card-body">
-        <%= t :no_doctors %>
-      </div>
+      <%= component :empty, title: t("empty.doctors.title"), description: t("empty.doctors.description"), image_name: 'no-data.svg' do %>
+        <%= link_to t("empty.doctors.cta"), new_doctor_path, class: "btn btn-primary" %>
+      <% end %>
     <% else %>
       <table class="table table-vcenter table-mobile-md card-table">
         <thead>

--- a/app/views/patients/index.html.erb
+++ b/app/views/patients/index.html.erb
@@ -99,9 +99,15 @@
 
     <% else %>
       <% if @patients.empty? %>
-        <div class="card-body text-center py-5">
-          <p class="text-muted mb-0"><%= t :no_patients %></p>
-        </div>
+        <% if current_user.practice.patients_count.to_i.zero? %>
+          <%= component :empty, title: t("empty.patients.title"), description: t("empty.patients.description"), image_name: 'no-data.svg' do %>
+            <%= link_to t("empty.patients.cta"), new_patient_path, class: "btn btn-primary" %>
+          <% end %>
+        <% else %>
+          <div class="card-body text-center py-5">
+            <p class="text-muted mb-0"><%= t :no_patients %></p>
+          </div>
+        <% end %>
       <% else %>
         <table class="table table-vcenter table-mobile-md card-table">
           <thead>

--- a/app/views/practices/show.html.erb
+++ b/app/views/practices/show.html.erb
@@ -130,16 +130,23 @@
                 },
                 {
                   key: :doctors,
-                  checked: @practice.doctors_count.to_i >= 1
+                  checked: @practice.doctors_count.to_i >= 1,
+                  url: new_doctor_path
                 },
                 {
                   key: :patients,
-                  checked: @practice.patients_count.to_i >= 1
+                  checked: @practice.patients_count.to_i >= 1,
+                  url: new_patient_path
                 }
               ] %>
 
               <% steps.each do |step| %>
-                <div class="list-group-item">
+                <% item_options = { class: 'list-group-item' } %>
+                <% if step[:url]
+                     item_options[:href] = step[:url]
+                     item_options[:class] += ' list-group-item-action'
+                   end %>
+                <%= content_tag(step[:url] ? :a : :div, item_options) do %>
                   <div class="row align-items-center">
                     <div class="col-auto">
                       <%= check_icon_tag step[:checked] %>
@@ -157,7 +164,7 @@
                       </div>
                     </div>
                   </div>
-                </div>
+                <% end %>
               <% end %>
             </div>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -371,6 +371,14 @@ en:
     payments:
       title: You haven't created any payments yet.
       description: Start collecting payments from your patients by configuring your practice in your settings.
+    doctors:
+      title: You haven't added any doctors yet.
+      description: Add your first doctor to start scheduling their appointments.
+      cta: Add your first doctor
+    patients:
+      title: You haven't added any patients yet.
+      description: Add your first patient to start booking appointments and keeping track of their visits.
+      cta: Add your first patient
   no_appointments:
     title: No appointments
     description: They don't have any appointments scheduled.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -348,6 +348,14 @@ es:
     payments:
       title: Aún no has creado ningún pago.
       description: Comienza a cobrar pagos de tus pacientes configurando tu clínica en la configuración.
+    doctors:
+      title: Aún no has agregado ningún doctor.
+      description: Agrega tu primer doctor para empezar a programar sus citas.
+      cta: Agregar tu primer doctor
+    patients:
+      title: Aún no has agregado ningún paciente.
+      description: Agrega tu primer paciente para empezar a programar citas y llevar el registro de sus visitas.
+      cta: Agregar tu primer paciente
   no_appointments:
     title: Sin citas
     description: No tienen ninguna cita programada.

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -365,6 +365,14 @@ pt:
     payments:
       title: Você ainda não criou nenhum pagamento.
       description: Comece a coletar pagamentos de seus pacientes configurando sua clínica nas configurações.
+    doctors:
+      title: Você ainda não adicionou nenhum médico.
+      description: Adicione seu primeiro médico para começar a agendar as consultas dele.
+      cta: Adicionar seu primeiro médico
+    patients:
+      title: Você ainda não adicionou nenhum paciente.
+      description: Adicione seu primeiro paciente para começar a agendar consultas e acompanhar suas visitas.
+      cta: Adicionar seu primeiro paciente
   no_appointments:
     title: Nenhum agendamento
     description: Eles não têm nenhum agendamento programado.

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -10,6 +10,9 @@ complete:
   connect_charges_enabled: true
   connect_payouts_enabled: true
   connect_details_submitted: true
+  # counter caches must match the child fixtures (Rails doesn't compute them for fixtures)
+  patients_count: 3
+  doctors_count: 3
 
 complete_another_language:
   id: 2
@@ -26,6 +29,7 @@ trialing_practice:
   timezone: Europe/London
   currency: usd
   email: trialing@odonto.me
+  patients_count: 1
 
 past_due_practice:
   id: 4

--- a/test/functional/doctors_controller_test.rb
+++ b/test/functional/doctors_controller_test.rb
@@ -18,6 +18,24 @@ class DoctorsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:doctors)
   end
 
+  test 'shows empty state cta when practice has no doctors' do
+    practice = practices(:complete)
+    Doctor.with_practice(practice.id).destroy_all
+    practice.update_columns(doctors_count: 0)
+
+    get :index
+
+    assert_response :success
+    assert_select "a[href='#{new_doctor_path}']"
+  end
+
+  test 'does not show empty state cta when practice has doctors' do
+    get :index
+
+    assert_response :success
+    assert_select "a[href='#{new_doctor_path}']", false
+  end
+
   test 'should get new' do
     get :new
     assert_response :success

--- a/test/functional/patients_controller_test.rb
+++ b/test/functional/patients_controller_test.rb
@@ -104,6 +104,57 @@ class PatientsControllerTest < ActionController::TestCase
     assert_equal 'all', assigns(:segment)
   end
 
+  test 'shows empty state cta when practice has no patients at all' do
+    practice = practices(:complete)
+    Patient.with_practice(practice.id).destroy_all
+    practice.update_columns(patients_count: 0)
+
+    get :index, params: { segment: 'all' }
+
+    assert_response :success
+    assert_empty assigns(:patients)
+    assert_select "a[href='#{new_patient_path}']"
+  end
+
+  test 'defaults to the all segment with empty state when practice has no patients' do
+    practice = practices(:complete)
+    Patient.with_practice(practice.id).destroy_all
+    practice.update_columns(patients_count: 0)
+
+    get :index
+
+    assert_response :success
+    assert_equal 'all', assigns(:segment)
+    assert_select "a[href='#{new_patient_path}']"
+  end
+
+  test 'still defaults to the today segment when practice has patients' do
+    get :index
+
+    assert_response :success
+    assert_equal 'today', assigns(:segment)
+  end
+
+  test 'does not show empty state cta when practice has patients' do
+    get :index, params: { segment: 'all' }
+
+    assert_response :success
+    assert_not_empty assigns(:patients)
+    assert_select "a[href='#{new_patient_path}']", false
+  end
+
+  test 'browsing a letter with no patients keeps the per-letter message when the practice has other patients' do
+    practice = practices(:complete)
+    practice.update_columns(patients_count: Patient.with_practice(practice.id).count)
+
+    get :index, params: { segment: 'all', letter: 'Z' }
+
+    assert_response :success
+    assert_empty assigns(:patients)
+    assert_select "a[href='#{new_patient_path}']", false
+    assert_select 'p', text: I18n.t(:no_patients)
+  end
+
   test 'segment pills not shown during search' do
     get :index, params: { term: 'test' }
     assert_response :success

--- a/test/functional/practices_controller_test.rb
+++ b/test/functional/practices_controller_test.rb
@@ -48,6 +48,9 @@ class PracticesControllerTest < ActionController::TestCase
     new_user = Practice.last.users.first
     assert UserConsent.accepted?(new_user, 'terms')
     assert UserConsent.accepted?(new_user, 'privacy')
+
+    # Verify default treatments were seeded for the new practice
+    assert_not_empty Practice.last.treatments
   end
 
   test 'should not create practice without consent' do
@@ -105,6 +108,9 @@ class PracticesControllerTest < ActionController::TestCase
 
     welcome_email = ActionMailer::Base.deliveries.last
     assert_equal I18n.t('mailers.practice.welcome.subject', locale: :es), welcome_email.subject
+
+    # Verify default treatments were seeded in Spanish
+    assert_includes Practice.last.treatments.pluck(:name), 'Limpieza dental'
   end
 
   test 'should create practice with English locale for unsupported browser language' do
@@ -121,6 +127,27 @@ class PracticesControllerTest < ActionController::TestCase
     end
 
     assert_equal 'en', Practice.last.locale
+  end
+
+  test 'should show actionable checklist links with doctors before patients for a fresh practice' do
+    @controller.session['user'] = nil
+
+    practice = { name: 'Fresh Practice',
+                 timezone: 'Europe/London',
+                 users_attributes: { '0' => { 'email' => 'fresh@odonto.me', 'password' => '1234567890',
+                                              'password_confirmation' => '1234567890' } } }
+
+    post :create, params: { practice: practice, consent_terms: '1', consent_privacy: '1' }
+
+    get :show, params: { id: Practice.last.to_param }
+
+    assert_response :success
+    assert_select "a[href='#{new_doctor_path}']"
+    assert_select "a[href='#{new_patient_path}']"
+
+    doctors_position = response.body.index(new_doctor_path)
+    patients_position = response.body.index(new_patient_path)
+    assert doctors_position < patients_position, 'expected the doctors step to appear before the patients step'
   end
 
   test 'should update practice with custom review URL' do

--- a/test/functional/welcome_controller_test.rb
+++ b/test/functional/welcome_controller_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class WelcomeControllerTest < ActionController::TestCase
+  teardown do
+    I18n.locale = I18n.default_locale
+  end
+
+  test 'redirects unauthenticated visitors to sign in' do
+    @controller.session['user'] = nil
+
+    get :index
+
+    assert_redirected_to signin_path
+  end
+
+  test 'admin of a practice with no doctors is redirected to the practice checklist' do
+    practices(:complete).update_columns(doctors_count: 0, patients_count: 5)
+    @controller.session['user'] = users(:founder)
+
+    get :index
+
+    assert_redirected_to practice_path
+  end
+
+  test 'admin of a practice with no patients is redirected to the practice checklist' do
+    practices(:complete).update_columns(doctors_count: 2, patients_count: 0)
+    @controller.session['user'] = users(:founder)
+
+    get :index
+
+    assert_redirected_to practice_path
+  end
+
+  test 'admin of a fully set up practice keeps the existing datebook redirect' do
+    practices(:complete).update_columns(doctors_count: 2, patients_count: 3)
+    @controller.session['user'] = users(:founder)
+
+    get :index
+
+    assert_redirected_to datebook_path(datebooks(:playa_del_carmen))
+  end
+
+  test 'non-admin user is unaffected by the practice checklist redirect' do
+    practices(:complete).update_columns(doctors_count: 0, patients_count: 0)
+    @controller.session['user'] = users(:perishable)
+
+    get :index
+
+    assert_redirected_to datebook_path(datebooks(:playa_del_carmen))
+  end
+
+  test 'superadmin is still sent to the practices admin index regardless of practice setup' do
+    practices(:complete).update_columns(doctors_count: 0, patients_count: 0)
+    @controller.session['user'] = users(:superadmin)
+
+    get :index
+
+    assert_redirected_to practices_admin_path
+  end
+end


### PR DESCRIPTION
New signups land in an empty app with no guided path: the onboarding checklist was dead text, later logins dropped users on an empty calendar, and every section started blank. Admin data shows signups add 0-1 test patients and never return.

## Changes

- Checklist steps on the practice dashboard are now real links (doctors before patients)
- Admins land on the checklist after every login until the practice has a doctor and a patient
- Suggested treatments are seeded automatically at signup, in the practice's language
- Doctors and Patients pages greet empty practices with a clear 'add your first' action, and zero-patient practices land on it directly
- Fixes stale counter caches in practice fixtures

Sample/demo data intentionally left out — it would fight the 0-patient lifecycle emails from #1107.

## Deploy

Nothing to configure.

## Tests

497 runs, 2059 assertions, 0 failures (14 new tests). Full flow verified in the running app: signup → checklist → one-click to add-doctor form, seeded treatments, both empty states.