### PR TITLE
feat(admin): show 30-day signup funnel on the practices page

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -9,6 +9,13 @@ class AdminController < ApplicationController
     @filter = params[:filter] || 'all'
     @total_practices = Practice.count
 
+    recent_signups = Practice.where('practices.created_at > ?', 30.days.ago)
+    @funnel = {
+      signups: recent_signups.count,
+      activated: recent_signups.where('doctors_count > 0 AND patients_count > 0').count,
+      subscribed: recent_signups.joins(:subscription).where(subscriptions: { status: 'active' }).count
+    }
+
     case @filter
     when 'all'
       @practices = Practice.includes(:subscription).order('created_at desc').limit(250)

--- a/app/views/admin/practices.html.erb
+++ b/app/views/admin/practices.html.erb
@@ -7,6 +7,11 @@
       <h2 class="page-title">
         Practices
       </h2>
+      <div class="text-muted mt-1">
+        Last 30 days: <%= @funnel[:signups] %> signups
+        · <%= @funnel[:activated] %> activated (<%= @funnel[:signups].zero? ? 0 : (@funnel[:activated] * 100 / @funnel[:signups]) %>%)
+        · <%= @funnel[:subscribed] %> subscribed
+      </div>
     </div>
 		<div class="col-auto ms-auto">
         <div class="btn-list">

--- a/test/functional/admin_controller_test.rb
+++ b/test/functional/admin_controller_test.rb
@@ -14,6 +14,33 @@ class AdminControllerTest < ActionController::TestCase
     assert_equal 'all', assigns(:filter)
   end
 
+  test 'shows signup funnel stats for the last 30 days' do
+    fresh = practices(:trialing_practice)
+    fresh.update_columns(created_at: 3.days.ago, doctors_count: 1, patients_count: 2)
+    activated_and_paying = practices(:complete)
+    activated_and_paying.update_columns(created_at: 10.days.ago, doctors_count: 3, patients_count: 3)
+    activated_and_paying.subscription.update_columns(status: 'active')
+    Practice.where.not(id: [fresh.id, activated_and_paying.id]).update_all(created_at: 60.days.ago)
+
+    get :practices
+
+    assert_response :success
+    assert_equal 2, assigns(:funnel)[:signups]
+    assert_equal 2, assigns(:funnel)[:activated]
+    assert_equal 1, assigns(:funnel)[:subscribed]
+    assert_match(/Last 30 days: 2 signups\s+· 2 activated \(100%\)\s+· 1 subscribed/, response.body)
+  end
+
+  test 'funnel handles zero signups without division errors' do
+    Practice.update_all(created_at: 60.days.ago)
+
+    get :practices
+
+    assert_response :success
+    assert_equal 0, assigns(:funnel)[:signups]
+    assert_match(/Last 30 days: 0 signups/, response.body)
+  end
+
   test 'should get practices with active filter' do
     get :practices, params: { filter: 'active' }
     assert_response :success


### PR DESCRIPTION
Watching whether the conversion fixes (#1107, #1108, site#7) work currently means counting rows by hand. This adds one line above the practices table: `Last 30 days: N signups · N activated (X%) · N subscribed` — activated means ≥1 doctor and ≥1 patient, subscribed means a Stripe-active subscription in that cohort. Three COUNT queries, superadmin-only page.

## Test plan

- New tests: funnel stats with a mixed cohort (activated/subscribed counts and rendered line), zero-signups division guard
- Full suite: 499 runs, 2069 assertions, 0 failures
- Verified rendered in the running app