### PR TITLE
feat(ads): restore signup conversion tracking on acquisition pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,11 @@
 
 	  <link rel="shortcut icon" href="/favicon.ico">
 
+  <%# Ads tag on the one post-signup page view only — the rest of the
+      logged-in app stays free of third-party tracking %>
+  <% if params[:ref] == 'signup' %>
+    <%= render 'shared/google_ads' %>
+  <% end %>
 </head>
 
 <body class="theme-light" id="app-body">

--- a/app/views/layouts/user_sessions.html.erb
+++ b/app/views/layouts/user_sessions.html.erb
@@ -26,6 +26,7 @@
       rel="stylesheet"
       href="https://unpkg.com/@tabler/core@latest/dist/css/tabler.min.css"
     />
+    <%= render 'shared/google_ads' %>
   </head>
 
   <body class="border-top-wide border-primary d-flex flex-column">

--- a/app/views/practices/show.html.erb
+++ b/app/views/practices/show.html.erb
@@ -177,3 +177,11 @@
       <%= render partial: 'practices/weekly_analytics' %>
     </div>
   </div>
+
+<% if params[:ref] == 'signup' && ENV['GOOGLE_ADS_SIGNUP_CONVERSION'].present? %>
+  <script>
+    if (typeof gtag === 'function') {
+      gtag('event', 'conversion', { 'send_to': '<%= ENV['GOOGLE_ADS_SIGNUP_CONVERSION'] %>' });
+    }
+  </script>
+<% end %>

--- a/app/views/shared/_google_ads.html.erb
+++ b/app/views/shared/_google_ads.html.erb
@@ -1,0 +1,16 @@
+<%# Google Ads tag, env-gated: does nothing unless GOOGLE_ADS_ID is set.
+    Only rendered on acquisition pages (signup/signin and the single
+    post-signup page view) — never on regular logged-in pages.
+    No SRI integrity hash: gtag.js is generated dynamically per tag and
+    changes on Google's schedule, so a pinned hash would break it. %>
+<% if ENV['GOOGLE_ADS_ID'].present? %>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GOOGLE_ADS_ID'] %>"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('set', 'linker', { 'domains': ['odonto.me', 'my.odonto.me'] });
+    gtag('config', '<%= ENV['GOOGLE_ADS_ID'] %>');
+  </script>
+<% end %>

--- a/test/functional/practices_controller_test.rb
+++ b/test/functional/practices_controller_test.rb
@@ -129,6 +129,37 @@ class PracticesControllerTest < ActionController::TestCase
     assert_equal 'en', Practice.last.locale
   end
 
+  test 'fires the ads conversion only on the post-signup page view' do
+    ENV['GOOGLE_ADS_ID'] = 'AW-TEST'
+    ENV['GOOGLE_ADS_SIGNUP_CONVERSION'] = 'AW-TEST/label'
+
+    get :show, params: { id: practices(:complete).to_param, ref: 'signup' }
+    assert_response :success
+    assert_includes response.body, 'googletagmanager.com/gtag/js?id=AW-TEST'
+    assert_includes response.body, "'send_to': 'AW-TEST/label'"
+
+    get :show, params: { id: practices(:complete).to_param }
+    assert_not_includes response.body, 'googletagmanager.com'
+    assert_not_includes response.body, "'send_to'"
+  ensure
+    ENV.delete('GOOGLE_ADS_ID')
+    ENV.delete('GOOGLE_ADS_SIGNUP_CONVERSION')
+  end
+
+  test 'loads the ads tag on the signup page but stays off without env config' do
+    @controller.session['user'] = nil
+
+    ENV['GOOGLE_ADS_ID'] = 'AW-TEST'
+    get :new
+    assert_includes response.body, 'googletagmanager.com/gtag/js?id=AW-TEST'
+
+    ENV.delete('GOOGLE_ADS_ID')
+    get :new
+    assert_not_includes response.body, 'googletagmanager.com'
+  ensure
+    ENV.delete('GOOGLE_ADS_ID')
+  end
+
   test 'should show actionable checklist links with doctors before patients for a fresh practice' do
     @controller.session['user'] = nil
 


### PR DESCRIPTION
Restores the env-gated Google Ads tag removed in 8921c3f, contained to acquisition surfaces only: the signup/signin pages and the single post-signup page view (`ref=signup`), where the conversion event fires. Logged-in product pages stay tracker-free. Renders nothing unless `GOOGLE_ADS_ID` / `GOOGLE_ADS_SIGNUP_CONVERSION` are set. Adds the cross-domain linker so ad clicks landing on odonto.me attribute to signups here.

## Test plan

- New tests: conversion fires only with `ref=signup` + env set; tag renders on signup page with env, absent without; logged-in pages never include it
- Full suite: 501 runs, 2082 assertions, 0 failures