### PR TITLE
fix(agent): scope patient and doctor lookups to the authenticated practice

### DIFF
--- a/app/controllers/api/agent/appointments_controller.rb
+++ b/app/controllers/api/agent/appointments_controller.rb
@@ -17,6 +17,8 @@ module Api
 
       def create
         datebook = resolve_datebook
+        return if reject_foreign_doctor!
+
         appointment = Appointment.new(appointment_params)
         appointment.datebook_id = datebook.id
         apply_time_params(appointment)
@@ -35,6 +37,8 @@ module Api
 
       def update
         datebook = resolve_datebook
+        return if reject_foreign_doctor!
+
         appointment = Appointment.where(id: params[:id], datebook_id: datebook.id).first
 
         unless appointment
@@ -52,6 +56,17 @@ module Api
       end
 
       private
+
+      # A doctor from another practice must never be assigned to an appointment,
+      # otherwise the response would echo back that practice's doctor name.
+      def reject_foreign_doctor!
+        doctor_id = params.dig(:appointment, :doctor_id)
+        return false if doctor_id.blank?
+        return false if Doctor.with_practice(@practice.id).exists?(id: doctor_id)
+
+        render json: { errors: [I18n.t('agents.errors.doctor_not_found')] }, status: :unprocessable_entity
+        true
+      end
 
       def appointment_params
         params.require(:appointment).permit(:doctor_id, :starts_at, :ends_at, :notes)

--- a/app/controllers/api/agent/mcp/tool_executor.rb
+++ b/app/controllers/api/agent/mcp/tool_executor.rb
@@ -204,9 +204,8 @@ module Api
 
           if patient_name.present?
             result_id = Patient.find_or_create_from(patient_name, @practice.id)
-            # Verify the patient belongs to this practice. find_or_create_from
-            # treats numeric strings as patient ID lookups without practice
-            # scoping, which could link to a patient from another practice.
+            # find_or_create_from is practice-scoped, so this is a second line of
+            # defence on a tenant boundary rather than the only one.
             return result_id if result_id && Patient.with_practice(@practice.id).where(id: result_id).exists?
           end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -170,8 +170,9 @@ class Patient < ApplicationRecord
       patient_id_or_name = patient.id
     end
 
-    # validate that this patient really exists
-    patient_id_or_name = nil unless Patient.exists?(patient_id_or_name)
+    # validate that this patient really exists *within this practice*, so a numeric
+    # value can never resolve to another practice's patient
+    patient_id_or_name = nil unless Patient.exists?(id: patient_id_or_name, practice_id: practice_id)
 
     patient_id_or_name
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -764,6 +764,7 @@ en:
     errors:
       unauthorized: "Unauthorized"
       not_found: "Not found"
+      doctor_not_found: "Doctor not found in this practice"
     mcp:
       errors:
         parse_error: "Parse error"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -715,6 +715,7 @@ es:
     errors:
       unauthorized: "No autorizado"
       not_found: "No encontrado"
+      doctor_not_found: "Doctor no encontrado en esta clínica"
     mcp:
       errors:
         parse_error: "Error de análisis"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -755,6 +755,7 @@ pt:
     errors:
       unauthorized: "Não autorizado"
       not_found: "Não encontrado"
+      doctor_not_found: "Dentista não encontrado nesta clínica"
     mcp:
       errors:
         parse_error: "Erro de análise"

--- a/test/functional/api/agent/appointments_controller_test.rb
+++ b/test/functional/api/agent/appointments_controller_test.rb
@@ -173,7 +173,89 @@ class Api::Agent::AppointmentsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
+  test 'should not link an appointment to a patient from another practice' do
+    raw_key = enable_agent_access(@practice)
+    @request.headers['X-Agent-Key'] = raw_key
+
+    foreign_patient = patients(:three)
+    assert_not_equal @practice.id, foreign_patient.practice_id,
+                     'fixture precondition: patient must belong to a different practice'
+
+    post :create,
+         params: {
+           datebook_id: @datebook.id,
+           appointment: {
+             doctor_id: @doctor.id,
+             patient_name: foreign_patient.id.to_s,
+             starts_at: 3.days.from_now.to_i,
+             ends_at: (3.days.from_now + 1.hour).to_i
+           }
+         },
+         format: :json
+
+    assert_response :unprocessable_entity
+    assert_not Appointment.exists?(patient_id: foreign_patient.id, datebook_id: @datebook.id),
+               'Must not link an appointment to a patient from another practice'
+    assert_not_includes @response.body, foreign_patient.firstname,
+                        'Must not leak the name of a patient from another practice'
+  end
+
+  test 'should reject creating an appointment for a doctor from another practice' do
+    raw_key = enable_agent_access(@practice)
+    @request.headers['X-Agent-Key'] = raw_key
+
+    foreign_doctor = foreign_practice_doctor
+
+    assert_no_difference 'Appointment.count' do
+      post :create,
+           params: {
+             datebook_id: @datebook.id,
+             appointment: {
+               doctor_id: foreign_doctor.id,
+               patient_id: @patient.id,
+               starts_at: 3.days.from_now.to_i,
+               ends_at: (3.days.from_now + 1.hour).to_i
+             }
+           },
+           format: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_not_includes @response.body, foreign_doctor.firstname,
+                        'Must not leak the name of a doctor from another practice'
+  end
+
+  test 'should reject reassigning an appointment to a doctor from another practice' do
+    raw_key = enable_agent_access(@practice)
+    @request.headers['X-Agent-Key'] = raw_key
+
+    appointment = appointments(:first_visit)
+    foreign_doctor = foreign_practice_doctor
+
+    patch :update,
+          params: {
+            datebook_id: @datebook.id,
+            id: appointment.id,
+            appointment: { doctor_id: foreign_doctor.id }
+          },
+          format: :json
+
+    assert_response :unprocessable_entity
+    appointment.reload
+    assert_not_equal foreign_doctor.id, appointment.doctor_id,
+                     'Must not reassign an appointment to a doctor from another practice'
+  end
+
   private
+
+  def foreign_practice_doctor
+    Doctor.create!(
+      practice_id: practices(:trialing_practice).id,
+      firstname: 'Foreign',
+      lastname: 'Doctor',
+      gender: 'female'
+    )
+  end
 
   def enable_agent_access(practice)
     practice.update!(agent_access_enabled: true)

--- a/test/functional/api/agent/mcp_controller_test.rb
+++ b/test/functional/api/agent/mcp_controller_test.rb
@@ -318,6 +318,36 @@ class Api::Agent::McpControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'should not link create_appointment to a patient from another practice' do
+    raw_key = enable_agent_access(@practice)
+    @request.headers['X-Agent-Key'] = raw_key
+
+    foreign_patient = patients(:three)
+    assert_not_equal @practice.id, foreign_patient.practice_id,
+                     'fixture precondition: patient must belong to a different practice'
+
+    start_time = 4.days.from_now.in_time_zone(@practice.timezone).change(hour: 10, min: 0)
+
+    assert_no_difference 'Appointment.count' do
+      post_mcp(
+        method: 'tools/call', id: 70,
+        params: {
+          name: 'create_appointment',
+          arguments: {
+            datebook_id: @datebook.id,
+            doctor_id: @doctor.id,
+            patient_name: foreign_patient.id.to_s,
+            starts_at: start_time.to_i.to_s,
+            ends_at: (start_time + 1.hour).to_i.to_s
+          }
+        }
+      )
+    end
+
+    assert_not_includes @response.body, foreign_patient.firstname,
+                        'Must not leak the name of a patient from another practice'
+  end
+
   # --- tools/call: update_appointment ---
 
   test 'should call update_appointment' do

--- a/test/unit/models/patient_test.rb
+++ b/test/unit/models/patient_test.rb
@@ -221,6 +221,26 @@ class PatientTest < ActiveSupport::TestCase
     assert_includes result_ids, patient_id, 'Patient created via find_or_create_from should be searchable'
   end
 
+  test 'find_or_create_from resolves a patient id from the same practice' do
+    patient = patients(:four)
+
+    result = Patient.find_or_create_from(patient.id.to_s.dup, patient.practice_id)
+
+    assert_equal patient.id, result.to_i
+  end
+
+  test 'find_or_create_from ignores a patient id from another practice' do
+    foreign_patient = patients(:three)
+    practice_id = practices(:complete).id
+
+    assert_not_equal practice_id, foreign_patient.practice_id,
+                     'fixture precondition: patient must belong to a different practice'
+
+    result = Patient.find_or_create_from(foreign_patient.id.to_s.dup, practice_id)
+
+    assert_nil result, 'A patient id belonging to another practice must not resolve'
+  end
+
   test 'destroy_nils is scoped to the current practice' do
     patient = patients(:one)
 


### PR DESCRIPTION
Two agent API lookups weren't scoped to the practice, so one practice could attach another practice's patient or doctor to its own appointment and read that person's name back in the response.

Scoped the patient lookup inside `Patient.find_or_create_from` (fixes all four callers, including the web controller's `as_values_patient_id`) and added an out-of-practice doctor guard to the agent REST controller, matching the MCP executor.

## Test plan

- [x] Cross-practice patient rejected (model)
- [x] Cross-practice patient rejected (REST)
- [x] Cross-practice patient rejected (MCP)
- [x] Cross-practice doctor rejected on create
- [x] Cross-practice doctor rejected on update
- [x] Same-practice patient still resolves
- [x] Web booking form unaffected
- [x] Full suite passes
- [x] es/pt copy reviewed