### PR TITLE
fix(appointments): require datebook, doctor and patient to share a practice

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -36,6 +36,7 @@ class Appointment < ApplicationRecord
   validates_presence_of :datebook_id, :doctor_id, :patient_id
   validates_numericality_of :datebook_id, :doctor_id, :patient_id
   validate :ends_at_should_be_later_than_starts_at
+  validate :associations_must_share_a_practice
   validates :notes, length: { within: 0..255 }, allow_blank: true
 
   # callbacks
@@ -149,6 +150,17 @@ class Appointment < ApplicationRecord
     return unless !starts_at.nil? && !ends_at.nil? && (starts_at >= ends_at)
 
     errors.add(:base, I18n.t('errors.messages.invalid_date_range'))
+  end
+
+  # The datebook, doctor and patient must all belong to the same practice, so a
+  # missing scope in a controller cannot link records across practices.
+  def associations_must_share_a_practice
+    return if datebook.nil?
+
+    practice_id = datebook.practice_id
+
+    errors.add(:doctor_id, I18n.t('errors.messages.different_practice')) if doctor && doctor.practice_id != practice_id
+    errors.add(:patient_id, I18n.t('errors.messages.different_practice')) if patient && patient.practice_id != practice_id
   end
 
   def set_ends_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,6 +213,7 @@ en:
       go_home: Go home
     messages:
       invalid_date_range: The chosen dates are invalid
+      different_practice: Must belong to this practice
       invalid_email_format: Invalid format
       unauthorised: You don't have permission to do this
       not_found: It may have been deleted or never existed

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -209,6 +209,7 @@ es:
       go_home: Ir a la página principal
     messages:
       invalid_date_range: Las fechas son invalidas.
+      different_practice: Debe pertenecer a esta clínica
       invalid_email_format: Formato invalido.
       unauthorised: No posees los permisos necesarios para hacer esto.
       not_found: Puede ser que haya sido borrado o nunca existió

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -211,6 +211,7 @@ pt:
       go_home: Ir para início
     messages:
       invalid_date_range: As datas escolhidas são inválidas
+      different_practice: Deve pertencer a esta clínica
       invalid_email_format: Formato inválido
       unauthorised: Você não tem permissão para fazer isso
       not_found: Pode ter sido deletado ou nunca existiu

--- a/test/unit/models/appointment_test.rb
+++ b/test/unit/models/appointment_test.rb
@@ -9,6 +9,29 @@ class AppointmentTest < ActiveSupport::TestCase
 
   setup :create_session
 
+  test 'is valid when datebook, doctor and patient share a practice' do
+    assert appointments(:first_visit).valid?
+  end
+
+  test 'is invalid when the doctor belongs to another practice' do
+    appointment = appointments(:first_visit)
+    appointment.doctor = Doctor.create!(
+      practice_id: practices(:trialing_practice).id,
+      firstname: 'Foreign', lastname: 'Doctor', gender: 'female'
+    )
+
+    assert appointment.invalid?
+    assert appointment.errors[:doctor_id].any?
+  end
+
+  test 'is invalid when the patient belongs to another practice' do
+    appointment = appointments(:first_visit)
+    appointment.patient = patients(:three)
+
+    assert appointment.invalid?
+    assert appointment.errors[:patient_id].any?
+  end
+
   test 'appointment attributes must not be empty' do
     appointment = Appointment.new
 


### PR DESCRIPTION
Follow-up to #1112. Both bugs fixed there were the same shape — a controller forgot to scope a lookup, letting one practice's appointment point at another practice's doctor or patient.

Adds the check at the model instead, so the mistake can't be represented regardless of which controller does the write.

## Test plan

- [x] Cross-practice doctor rejected
- [x] Cross-practice patient rejected
- [x] Same-practice appointment still valid
- [x] Full suite passes
- [x] No violating rows in dev DB
- [ ] Production rows checked
- [ ] es/pt copy reviewed