### PR TITLE
fix(webhooks): respond 404 when a stripe event has no matching practice

### DIFF
--- a/app/controllers/api/webhooks/stripe_controller.rb
+++ b/app/controllers/api/webhooks/stripe_controller.rb
@@ -56,6 +56,12 @@ module Api::Webhooks
       end
 
       head 200
+    rescue ActiveRecord::RecordNotFound
+      # A 404 makes Stripe retry later: if the customer reference simply hasn't
+      # been saved yet (checkout webhooks can arrive out of order) the retry
+      # will succeed; events for deleted practices stop once retries exhaust.
+      puts "Stripe webhooks - no matching record for event: #{event.type}"
+      head :not_found
     end
 
     private

--- a/test/functional/api/webhooks/stripe_controller_test.rb
+++ b/test/functional/api/webhooks/stripe_controller_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Api::Webhooks::StripeControllerTest < ActionController::TestCase
+  setup do
+    @practice = practices(:complete_another_language)
+    @practice.update!(stripe_customer_id: 'cus_odontome_2')
+  end
+
+  test 'updates the subscription from a subscription event' do
+    post_signed_event subscription_event(customer: 'cus_odontome_2', status: 'past_due')
+
+    assert_response :ok
+    assert_equal 'past_due', @practice.subscription.reload.status
+  end
+
+  test 'responds with not found when no practice matches the stripe customer' do
+    post_signed_event subscription_event(customer: 'cus_gone_123', status: 'active')
+
+    assert_response :not_found
+  end
+
+  test 'rejects an invalid signature' do
+    @request.headers['Stripe-Signature'] = 't=1,v1=invalid'
+    post :event, body: subscription_event(customer: 'cus_odontome_2', status: 'active')
+
+    assert_response :bad_request
+  end
+
+  private
+
+  # customer.subscription.updated exercises update_database_subscription — the
+  # same method the invoice.* events reach — without needing to stub the
+  # Stripe::Subscription.retrieve network call those events make first.
+  def subscription_event(customer:, status:)
+    {
+      id: 'evt_test_1',
+      object: 'event',
+      type: 'customer.subscription.updated',
+      data: {
+        object: {
+          id: 'sub_test_1',
+          object: 'subscription',
+          customer: customer,
+          status: status,
+          cancel_at_period_end: false,
+          current_period_start: 2.days.ago.to_i,
+          current_period_end: 28.days.from_now.to_i
+        }
+      }
+    }.to_json
+  end
+
+  def post_signed_event(payload)
+    timestamp = Time.now.to_i
+    secret = Rails.configuration.stripe[:webhook_secret]
+    signature = OpenSSL::HMAC.hexdigest('SHA256', secret, "#{timestamp}.#{payload}")
+    @request.headers['Stripe-Signature'] = "t=#{timestamp},v1=#{signature}"
+
+    post :event, body: payload
+  end
+end


### PR DESCRIPTION
Fixes the top-priority open error in Bugsnag: `ActiveRecord::RecordNotFound` in `api/webhooks/stripe#event` (5 events since Aug 1). [View in Bugsnag](https://app.bugsnag.com/odontome-prod/odontome-prod/errors/6a6e3a910c8570e1dc7baac3).

## Summary

Stripe webhooks referencing a `stripe_customer_id` with no matching practice hit `Practice.find_by!` and blow up. Two real sources: Stripe doesn't guarantee webhook order, so `invoice.payment_succeeded` can arrive before `checkout.session.completed` has saved the customer id; and deleted practices have no Stripe-side cleanup, so their subscription events keep arriving.

The fix rescues `ActiveRecord::RecordNotFound` at the action level and responds with a deliberate 404: the Bugsnag noise stops, while Stripe still retries — which self-heals the out-of-order case once the customer id lands. Also adds this controller's first functional tests, using real HMAC-signed payloads (no mocks).

Follow-up flagged separately: cancel the Stripe subscription when a practice is deleted, so orphaned events stop at the source.

## Remaining open errors (triage)

| Error | Context | Tier | Events | Users | Assessment |
|---|---|---|---|---|---|
| `ActionController::MissingExactTemplate` | `user_sessions#show` | 4 — noise | 4 | 2 | `GET /user_session` has no HTML view; low-volume stray navigation/bots. Wants a graceful redirect, not a template. |

## Test plan

- [ ] `bin/rails test test/functional/api/webhooks/stripe_controller_test.rb`
- [ ] Full suite green
- [ ] Bugsnag error stops after deploy