### PR TITLE
fix(practices): delete Stripe customer when a practice is destroyed

### DIFF
--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -29,6 +29,7 @@ class Practice < ApplicationRecord
   before_validation :set_first_user_data, on: :create
   after_create :create_first_datebook, :create_trial_subscription, :populate_default_treatments
   before_create :set_email_practice
+  before_destroy :delete_stripe_customer
 
   def set_as_cancelled
     self.cancelled_at = Time.now
@@ -178,6 +179,16 @@ class Practice < ApplicationRecord
   end
 
   private
+
+  # Deleting the Stripe customer also cancels any active subscriptions and
+  # stops Stripe from sending webhooks for a practice that no longer exists.
+  def delete_stripe_customer
+    return if stripe_customer_id.nil?
+
+    Stripe::Customer.delete(stripe_customer_id)
+  rescue Stripe::StripeError => e
+    Rails.logger.error "Failed to delete Stripe customer for practice #{id}: #{e.message}"
+  end
 
   def set_email_practice
     self.email = users.first.email

--- a/test/unit/models/practice_test.rb
+++ b/test/unit/models/practice_test.rb
@@ -110,6 +110,46 @@ class PracticeTest < ActiveSupport::TestCase
     assert_equal -5, ActiveSupport::TimeZone[practice.timezone].utc_offset / 3600
   end
 
+  test 'destroying a practice deletes its Stripe customer' do
+    practice = practices(:canceled_practice)
+    practice.update_column(:stripe_customer_id, 'cus_test123')
+
+    deleted_customer_ids = []
+    delete_stub = ->(id) { deleted_customer_ids << id }
+
+    Stripe::Customer.stub(:delete, delete_stub) do
+      practice.destroy
+    end
+
+    assert_equal ['cus_test123'], deleted_customer_ids
+    assert_not Practice.exists?(practice.id)
+  end
+
+  test 'destroying a practice without a Stripe customer does not call Stripe' do
+    practice = practices(:canceled_practice)
+
+    delete_stub = ->(_id) { flunk 'Stripe::Customer.delete should not be called' }
+
+    Stripe::Customer.stub(:delete, delete_stub) do
+      practice.destroy
+    end
+
+    assert_not Practice.exists?(practice.id)
+  end
+
+  test 'destroying a practice proceeds when the Stripe customer is already gone' do
+    practice = practices(:canceled_practice)
+    practice.update_column(:stripe_customer_id, 'cus_missing')
+
+    delete_stub = ->(_id) { raise Stripe::InvalidRequestError.new('No such customer: cus_missing', 'id') }
+
+    Stripe::Customer.stub(:delete, delete_stub) do
+      assert practice.destroy
+    end
+
+    assert_not Practice.exists?(practice.id)
+  end
+
   test 'practice allows blank custom_review_url' do
     practice = practices(:complete)
     practice.custom_review_url = ''


### PR DESCRIPTION
## Summary

Destroying a practice (admin action or the `delete_practices_cancelled_a_while_ago` task) left its Stripe customer and subscription untouched, so cards could keep being charged and Stripe kept emitting webhooks for orphaned customers — which the webhook endpoint now answers with 404s, degrading endpoint health.

A `before_destroy` callback on `Practice` now deletes the Stripe customer, which per Stripe's documented behavior immediately cancels any active subscriptions and stops future webhooks for that customer. The callback is skipped when the practice has no `stripe_customer_id`, and any `Stripe::StripeError` (missing/already-deleted customer, outage) is logged and never blocks the deletion. Both deletion paths run model callbacks, so one callback covers them.

## Test plan

- [x] Stripe customer deleted on destroy
- [x] No Stripe call without customer ID
- [x] Stripe errors don't block deletion
- [x] Full suite green (511 runs)