### PR TITLE
fix(sessions): redirect GET /user_session to the dashboard

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,7 +7,9 @@ class UserSessionsController < ApplicationController
 
   def new; end
 
-  def show; end
+  def show
+    redirect_to root_url
+  end
 
   def create
     # Look up User in db by the email address submitted to the login form and

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
   resources :reviews
 
   # authentication
-  resource :user_session
+  resource :user_session, only: %i[new create show destroy]
   get '/signin' => 'user_sessions#new', :as => :signin
   delete '/logout' => 'user_sessions#destroy', :as => :logout
   get '/signup' => 'practices#new', :as => :signup

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -8,6 +8,19 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'should redirect show to root when signed in' do
+    @controller.session['user'] = users(:founder)
+    get :show
+
+    assert_redirected_to root_url
+  end
+
+  test 'should redirect show to signin when signed out' do
+    get :show
+
+    assert_redirected_to signin_path
+  end
+
   test 'should create user session if valid params are given' do
     post :create, params: { signin: { email: users(:founder).email, password: '1234567890' } }
 

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -21,6 +21,11 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_redirected_to signin_path
   end
 
+  test 'should not route to edit or update' do
+    assert_raises(ActionController::UrlGenerationError) { get :edit }
+    assert_raises(ActionController::UrlGenerationError) { patch :update }
+  end
+
   test 'should create user session if valid params are given' do
     post :create, params: { signin: { email: users(:founder).email, password: '1234567890' } }
 


### PR DESCRIPTION
Signed-in users hitting `GET /user_session` got a 500 — the route existed but `show` had no template ([Bugsnag](https://app.bugsnag.com/odontome-prod/odontome-prod/errors/6a67d068fdca5cb0d6c4a24f)). Redirect `show` to the dashboard, and restrict `resource :user_session` to the actions that exist.

## Test plan

- [x] `bin/rails test`
- [x] No edit/update routes
- [ ] Signed in, `/user_session` → dashboard
- [ ] Signed out, `/user_session` → sign-in