### PR TITLE
fix(sessions): recover gracefully from stale CSRF tokens

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,12 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  # A long-open page can hold a CSRF token that no longer matches the session
+  # (e.g. the session cookie expired and the remember token rebuilt it), so
+  # recover with a fresh page instead of an error screen. The request is
+  # still rejected.
+  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_stale_page
+
   helper :all
 
   helper_method :current_session, :current_user, :user_is_admin?, :current_user_is_superadmin?, :impersonating?
@@ -169,6 +175,15 @@ class ApplicationController < ActionController::Base
              item: object,
              notice: message
            }
+  end
+
+  def handle_stale_page
+    message = I18n.t(:stale_page_message)
+    respond_to do |format|
+      format.html { redirect_back fallback_location: signin_path, allow_other_host: false, alert: message }
+      format.js { render js: "alert('#{helpers.j(message)}'); window.location.reload();" }
+      format.json { render json: { error: message }, status: :unprocessable_entity }
+    end
   end
 
   def add_user_info_to_bugsnag(event)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -475,6 +475,7 @@ en:
   signup: Sign up
   spanish: Spanish
   speciality: Speciality
+  stale_page_message: Sorry, that didn't go through — this page had been open for a while. Please try again.
   starts_at: Starts at
   status: Status
   subscriptions:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -427,6 +427,7 @@ es:
   signup: Registrate
   spanish: Español
   speciality: Especialidad
+  stale_page_message: Lo sentimos, eso no funcionó — esta página llevaba abierta mucho tiempo. Por favor, inténtalo de nuevo.
   starts_at: Comienza el
   status: Estatus
   subscriptions:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -466,6 +466,7 @@ pt:
   signup: Cadastrar-se
   spanish: Espanhol
   speciality: Especialidade
+  stale_page_message: Desculpe, não deu certo — esta página ficou aberta por muito tempo. Por favor, tente novamente.
   starts_at: Inicia às
   status: Status
   subscriptions:

--- a/test/functional/appointments_controller_test.rb
+++ b/test/functional/appointments_controller_test.rb
@@ -39,6 +39,26 @@ class AppointmentsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'should ask the browser to reload when the CSRF token is stale' do
+    appointment = {
+      doctor_id: 1,
+      starts_at: '2014-01-04 14:00:00 +0000',
+      ends_at: '2014-01-04 15:00:00 +0000'
+    }
+
+    ActionController::Base.allow_forgery_protection = true
+    assert_no_difference 'Appointment.count' do
+      post :create, params: { appointment: appointment, datebook_id: 1, as_values_patient_id: '4,' }, format: :js
+    end
+
+    assert_response :success
+    assert_includes response.body, 'window.location.reload'
+    # the message is JavaScript-escaped in the response, so match a plain part of it
+    assert_includes response.body, 'Please try again.'
+  ensure
+    ActionController::Base.allow_forgery_protection = false
+  end
+
   test 'should create an appointment with a new patient' do
     appointment = {
       doctor_id: 2,

--- a/test/functional/user_sessions_controller_test.rb
+++ b/test/functional/user_sessions_controller_test.rb
@@ -110,6 +110,17 @@ class UserSessionsControllerTest < ActionController::TestCase
     assert_redirected_to root_url
   end
 
+  test 'should redirect back to signin with a friendly message when the CSRF token is stale' do
+    ActionController::Base.allow_forgery_protection = true
+    post :create, params: { signin: { email: users(:founder).email, password: '1234567890' } }
+
+    assert_nil @controller.session['user']
+    assert_redirected_to signin_path
+    assert_equal I18n.t(:stale_page_message), flash[:alert]
+  ensure
+    ActionController::Base.allow_forgery_protection = false
+  end
+
   test 'should handle login with expired remember token gracefully' do
     user = users(:founder)
     user.remember_token = 'expired_token'


### PR DESCRIPTION
A page left open long enough for the session cookie to expire holds a CSRF token that no longer matches the session that the remember-token later rebuilds, so submitting it raised an unhandled [`ActionController::InvalidAuthenticityToken`](https://app.bugsnag.com/odontome-prod/odontome-prod/errors/699b7f8f5e6cc4bb55a009e9) (98 events / 53 users in the past week, hitting both the sign-in form and the datebook's remote appointment form — one user retried 16 times in 40 seconds). This adds a `rescue_from` in `ApplicationController` that keeps rejecting the request but recovers kindly: HTML redirects back with a friendly flash message, UJS responds with an alert plus `window.location.reload()` so the page picks up a fresh token, and JSON returns 422. The message is translated in all three locales.

## Test plan
- [ ] Full suite green
- [ ] Stale sign-in redirects back
- [ ] Stale UJS create reloads
- [ ] Copy reads well (en/es/pt)