### PR TITLE
fix(monitoring): discard bot MIME-probe noise

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,3 +1,7 @@
 Bugsnag.configure do |config|
   config.api_key = ENV['BUGSNAG_API_KEY']
+
+  # Bots probing with malformed Accept headers raise this before any app code
+  # runs; Rails already answers 406, so reporting it is pure noise.
+  config.discard_classes << 'ActionDispatch::Http::MimeNegotiation::InvalidType'
 end

--- a/test/unit/bugsnag_configuration_test.rb
+++ b/test/unit/bugsnag_configuration_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class BugsnagConfigurationTest < ActiveSupport::TestCase
+  test 'discards invalid MIME type errors from bot probes' do
+    exception = ActionDispatch::Http::MimeNegotiation::InvalidType.new(
+      '"../../../etc/services{{" is not a valid MIME type'
+    )
+    report = Bugsnag::Report.new(exception, Bugsnag.configuration)
+
+    Bugsnag.configuration.internal_middleware.run(report)
+
+    assert report.ignore?, 'expected Bugsnag to discard MimeNegotiation::InvalidType reports'
+  end
+end


### PR DESCRIPTION
Bots probing the homepage with malformed `Accept` headers (e.g. a path-traversal payload) make Rails raise [`ActionDispatch::Http::MimeNegotiation::InvalidType`](https://app.bugsnag.com/odontome-prod/odontome-prod/errors/6a715d6dc4bed0d93fd94eeb) before any app code runs. Rails already answers with a 406 and treats the exception as silent, so the Bugsnag report is pure noise — this adds the class to `discard_classes` so real errors keep reporting while these probes don't, with a test that runs the gem's actual discard middleware.

## Test plan
- [x] `bin/rails test` passes
- [ ] Deploy
- [ ] Mark error fixed in Bugsnag